### PR TITLE
Add support for specifying country

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ To search for apps on the App Store, use the `search` command.
 ```
 OVERVIEW: Search for iOS apps available on the App Store.
 
-USAGE: ipatool search [--limit <limit>] <term> [--log-level <log-level>]
+USAGE: ipatool search [--limit <limit>] [--country <country>] <term> [--log-level <log-level>]
 
 ARGUMENTS:
   <term>                  The term to search for. 
 
 OPTIONS:
   --limit <limit>         (default: 5)
+  --country <country>     The country to search in. (default: US)
   --log-level <log-level> (default: info)
   --version               Show the version.
   -h, --help              Show help information.
@@ -56,6 +57,7 @@ USAGE: ipatool download --bundle-identifier <bundle-identifier> [--email <email>
 OPTIONS:
   -b, --bundle-identifier <bundle-identifier>
                           The bundle identifier of the target iOS app. 
+  -c, --country <country> The country of the target iOS app. (default: US)
   -e, --email <email>     The email address for the Apple ID. 
   -p, --password <password>
                           The password for the Apple ID. 

--- a/Source/Commands/Download.swift
+++ b/Source/Commands/Download.swift
@@ -16,6 +16,9 @@ struct Download: ParsableCommand {
     @Option(name: [.short, .long], help: "The bundle identifier of the target iOS app.")
     private var bundleIdentifier: String
 
+    @Option(name: [.short, .long], help: "The country of the target iOS app.")
+    private var country: String = "US"
+
     @Option(name: [.short, .customLong("email")], help: "The email address for the Apple ID.")
     private var emailArgument: String?
 
@@ -29,7 +32,7 @@ struct Download: ParsableCommand {
 }
 
 extension Download {
-    mutating func app(with bundleIdentifier: String) -> iTunesResponse.Result {
+    mutating func app(with bundleIdentifier: String, country: String) -> iTunesResponse.Result {
         logger.log("Creating HTTP client...", level: .debug)
         let httpClient = HTTPClient(urlSession: URLSession.shared)
 
@@ -37,8 +40,8 @@ extension Download {
         let itunesClient = iTunesClient(httpClient: httpClient)
 
         do {
-            logger.log("Querying the iTunes Store for '\(bundleIdentifier)'...", level: .info)
-            return try itunesClient.lookup(bundleIdentifier: bundleIdentifier)
+            logger.log("Querying the iTunes Store for '\(bundleIdentifier)' in country '\(country)'...", level: .info)
+            return try itunesClient.lookup(bundleIdentifier: bundleIdentifier, country: country)
         } catch {
             logger.log("\(error)", level: .debug)
 
@@ -199,7 +202,7 @@ extension Download {
     
     mutating func run() throws {
         // Query for app
-        let app: iTunesResponse.Result = app(with: bundleIdentifier)
+        let app: iTunesResponse.Result = app(with: bundleIdentifier, country: country)
         logger.log("Found app: \(app.name) (\(app.version)).", level: .debug)
         
         // Get Apple ID email

--- a/Source/Commands/Search.swift
+++ b/Source/Commands/Search.swift
@@ -16,6 +16,9 @@ struct Search: ParsableCommand {
     @Option
     private var limit: Int = 5
 
+    @Option(help: "The two-letter (ISO 3166-1 alpha-2) country code for the store you want to search.")
+    var country: String = "US"
+
     @Argument(help: "The term to search for.")
     var term: String
 
@@ -26,7 +29,7 @@ struct Search: ParsableCommand {
 }
 
 extension Search {
-    mutating func results(with term: String) -> [iTunesResponse.Result] {
+    mutating func results(with term: String, country: String) -> [iTunesResponse.Result] {
         logger.log("Creating HTTP client...", level: .debug)
         let httpClient = HTTPClient(urlSession: URLSession.shared)
 
@@ -34,8 +37,8 @@ extension Search {
         let itunesClient = iTunesClient(httpClient: httpClient)
         
         do {
-            logger.log("Searching for '\(term)'...", level: .info)
-            let results = try itunesClient.search(term: term, limit: limit)
+            logger.log("Searching for '\(term)' using the '\(country)' store front...", level: .info)
+            let results = try itunesClient.search(term: term, limit: limit, country: country)
             
             guard !results.isEmpty else {
                 logger.log("No results found.", level: .error)
@@ -52,7 +55,7 @@ extension Search {
     
     mutating func run() throws {
         // Search the iTunes store
-        let results = results(with: term)
+        let results = results(with: term, country: country)
 
         // Compile output
         let output = results

--- a/Source/iTunes/iTunesClient.swift
+++ b/Source/iTunes/iTunesClient.swift
@@ -8,16 +8,16 @@
 import Foundation
 
 protocol iTunesClientInterface {
-    func lookup(bundleIdentifier: String, completion: @escaping (Result<iTunesResponse.Result, Error>) -> Void)
-    func search(term: String, limit: Int, completion: @escaping (Result<[iTunesResponse.Result], Error>) -> Void)
+    func lookup(bundleIdentifier: String, country: String, completion: @escaping (Result<iTunesResponse.Result, Error>) -> Void)
+    func search(term: String, limit: Int, country: String, completion: @escaping (Result<[iTunesResponse.Result], Error>) -> Void)
 }
 
 extension iTunesClientInterface {
-    func lookup(bundleIdentifier: String) throws -> iTunesResponse.Result {
+    func lookup(bundleIdentifier: String, country: String) throws -> iTunesResponse.Result {
         let semaphore = DispatchSemaphore(value: 0)
         var result: Result<iTunesResponse.Result, Error>?
         
-        lookup(bundleIdentifier: bundleIdentifier) {
+        lookup(bundleIdentifier: bundleIdentifier, country: country) {
             result = $0
             semaphore.signal()
         }
@@ -34,11 +34,11 @@ extension iTunesClientInterface {
         }
     }
     
-    func search(term: String, limit: Int) throws -> [iTunesResponse.Result] {
+    func search(term: String, limit: Int, country: String) throws -> [iTunesResponse.Result] {
         let semaphore = DispatchSemaphore(value: 0)
         var result: Result<[iTunesResponse.Result], Error>?
         
-        search(term: term, limit: limit) {
+        search(term: term, limit: limit, country: country) {
             result = $0
             semaphore.signal()
         }
@@ -63,8 +63,8 @@ final class iTunesClient: iTunesClientInterface {
         self.httpClient = httpClient
     }
     
-    func lookup(bundleIdentifier: String, completion: @escaping (Result<iTunesResponse.Result, Swift.Error>) -> Void) {
-        let request = iTunesRequest.lookup(bundleIdentifier: bundleIdentifier)
+    func lookup(bundleIdentifier: String, country: String, completion: @escaping (Result<iTunesResponse.Result, Swift.Error>) -> Void) {
+        let request = iTunesRequest.lookup(bundleIdentifier: bundleIdentifier, country: country)
         
         httpClient.send(request) { result in
             switch result {
@@ -82,8 +82,8 @@ final class iTunesClient: iTunesClientInterface {
         }
     }
     
-    func search(term: String, limit: Int, completion: @escaping (Result<[iTunesResponse.Result], Swift.Error>) -> Void) {
-        let request = iTunesRequest.search(term: term, limit: limit)
+    func search(term: String, limit: Int, country: String, completion: @escaping (Result<[iTunesResponse.Result], Swift.Error>) -> Void) {
+        let request = iTunesRequest.search(term: term, limit: limit, country: country)
         
         httpClient.send(request) { result in
             switch result {

--- a/Source/iTunes/iTunesRequest.swift
+++ b/Source/iTunes/iTunesRequest.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 enum iTunesRequest {
-    case search(term: String, limit: Int)
-    case lookup(bundleIdentifier: String)
+    case search(term: String, limit: Int, country: String)
+    case lookup(bundleIdentifier: String, country: String)
 }
 
 extension iTunesRequest: HTTPRequest {
@@ -28,10 +28,10 @@ extension iTunesRequest: HTTPRequest {
 
     var payload: HTTPPayload? {
         switch self {
-        case let .lookup(bundleIdentifier):
-            return .urlEncoding(["media": "software", "bundleId": bundleIdentifier, "limit": "1"])
-        case let .search(term, limit):
-            return .urlEncoding(["media": "software", "term": term, "limit": "\(limit)"])
+        case let .lookup(bundleIdentifier, country):
+            return .urlEncoding(["media": "software", "bundleId": bundleIdentifier, "limit": "1", "country": country])
+        case let .search(term, limit, country):
+            return .urlEncoding(["media": "software", "term": term, "limit": "\(limit)", "country": country])
         }
     }
 }


### PR DESCRIPTION
This PR adds support for specifying the country to search for or to download from.
Sometimes apps are not available in the US, which is the [default country](https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/iTuneSearchAPI/Searching.html) and can therefore not be found.
An example for this issue is the German "Corona-Warn-App":
```
ipatool search "Corona-Warn–App" --log-level debug
==> 🛠	[Debug] Creating HTTP client...
==> 🛠	[Debug] Creating iTunes client...
==> ℹ️	[Info] Searching for 'Corona-Warn–App'...
==> ℹ️	[Info] Found 5 results:
1. SwissCovid: ch.admin.bag.dp3t (1.5.0).
2. HEALTHLYNKED COVID-19 Tracker: app.HealthLynked.COVAID19Tracker (1.0.64).
3. Commander Compass Go: com.paully.commandercompasslite (3.9.17).
4. iHandy Level: com.ihandysoft.carpenter.level (1.70.3).
5. Conceptis Fill-a-Pix: com.conceptispuzzles.Fill-a-Pix (5.6).
```
```
ipatool download -b de.rki.coronawarnapp --log-level debug
==> 🛠	[Debug] Creating HTTP client...
==> 🛠	[Debug] Creating iTunes client...
==> ℹ️	[Info] Querying the iTunes Store for 'de.rki.coronawarnapp'...
==> 🛠	[Debug] appNotFound
==> ❌	[Error] Could not find app.
```

With this patch applied:
```
ipatool search --country DE "Corona-Warn–App" --log-level debug
==> 🛠	[Debug] Creating HTTP client...
==> 🛠	[Debug] Creating iTunes client...
==> ℹ️	[Info] Searching for 'Corona-Warn–App' in country 'DE'...
==> ℹ️	[Info] Found 5 results:
1. Corona-Warn-App: de.rki.coronawarnapp (2.2.1).
2. HEALTHLYNKED COVID-19 Tracker: app.HealthLynked.COVAID19Tracker (1.0.64).
3. NINA: de.materna.bbk.mobile (3.3.3).
4. Corona-Datenspende: de.rki.coronadatenspende (2.2.1).
5. STIKO-App: de.rki.impf-infos (5.1).
```
```
ipatool download --country DE -b de.rki.coronawarnapp --log-level debug
==> 🛠	[Debug] Creating HTTP client...
==> 🛠	[Debug] Creating iTunes client...
==> ℹ️	[Info] Querying the iTunes Store for 'de.rki.coronawarnapp' in country 'DE'...
==> 🛠	[Debug] Found app: Corona-Warn-App (2.2.1).
==> ⚠️	[Warning] Enter Apple ID email:
[...]
```