### PR TITLE
Fix Sinf patch when app contains a Watch App

### DIFF
--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -377,7 +377,9 @@ func (a *appstore) replicateZip(src *zip.ReadCloser, dst *zip.Writer, info *byte
 				return "", errors.Wrap(err, ErrDecompressInfoFile.Error())
 			}
 
-			appBundle = filepath.Base(strings.TrimSuffix(file.Name, ".app/Info.plist"))
+			if !strings.Contains(file.Name, "/Watch/") {
+				appBundle = filepath.Base(strings.TrimSuffix(file.Name, ".app/Info.plist"))
+			}
 
 			_, err = io.Copy(info, srcFileD)
 			if err != nil {

--- a/pkg/appstore/appstore_download_test.go
+++ b/pkg/appstore/appstore_download_test.go
@@ -868,7 +868,6 @@ var _ = Describe("AppStore (Download)", func() {
 							found = true
 							break
 						}
-						fmt.Println(f.Name)
 					}
 					Expect(found).To(BeFalse())
 				})

--- a/pkg/appstore/appstore_download_test.go
+++ b/pkg/appstore/appstore_download_test.go
@@ -773,7 +773,7 @@ var _ = Describe("AppStore (Download)", func() {
 				})
 			})
 
-			When("app uses modern FiarPlay protection", func() {
+			When("app uses modern FairPlay protection", func() {
 				BeforeEach(func() {
 					zipFile = zip.NewWriter(tmpFile)
 					w, err := zipFile.Create("Payload/Test.app/SC_Info/Manifest.plist")
@@ -808,6 +808,69 @@ var _ = Describe("AppStore (Download)", func() {
 					outputPath := strings.TrimSuffix(tmpFile.Name(), ".tmp")
 					err := as.Download("", outputPath, true)
 					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			When("app uses modern FairPlay protection and has Watch app", func() {
+				BeforeEach(func() {
+					zipFile = zip.NewWriter(tmpFile)
+					w, err := zipFile.Create("Payload/Test.app/SC_Info/Manifest.plist")
+					Expect(err).ToNot(HaveOccurred())
+
+					manifest, err := plist.Marshal(PackageManifest{
+						SinfPaths: []string{
+							"SC_Info/TestApp.sinf",
+						},
+					}, plist.BinaryFormat)
+					Expect(err).ToNot(HaveOccurred())
+
+					_, err = w.Write(manifest)
+					Expect(err).ToNot(HaveOccurred())
+
+					w, err = zipFile.Create("Payload/Test.app/Info.plist")
+					Expect(err).ToNot(HaveOccurred())
+
+					info, err := plist.Marshal(map[string]interface{}{
+						"CFBundleExecutable": "Test",
+					}, plist.BinaryFormat)
+					Expect(err).ToNot(HaveOccurred())
+
+					_, err = w.Write(info)
+					Expect(err).ToNot(HaveOccurred())
+
+					w, err = zipFile.Create("Payload/Test.app/Watch/Test Watch App.app/Info.plist")
+					Expect(err).ToNot(HaveOccurred())
+
+					watchInfo, err := plist.Marshal(map[string]interface{}{
+						"WKWatchKitApp": true,
+					}, plist.BinaryFormat)
+					Expect(err).ToNot(HaveOccurred())
+
+					_, err = w.Write(watchInfo)
+					Expect(err).ToNot(HaveOccurred())
+
+					err = zipFile.Close()
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("sinf is in the correct path", func() {
+					outputPath := strings.TrimSuffix(tmpFile.Name(), ".tmp")
+					err := as.Download("", outputPath, true)
+					Expect(err).ToNot(HaveOccurred())
+
+					r, err := zip.OpenReader(outputPath)
+					Expect(err).ToNot(HaveOccurred())
+    				defer r.Close()
+
+					found := false
+					for _, f := range r.File {
+						if f.Name == "Payload/Test Watch App.app/SC_Info/TestApp.sinf" {
+							found = true
+							break
+						}
+						fmt.Println(f.Name)
+					}
+					Expect(found).To(BeFalse())
 				})
 			})
 		})

--- a/pkg/appstore/appstore_download_test.go
+++ b/pkg/appstore/appstore_download_test.go
@@ -860,7 +860,7 @@ var _ = Describe("AppStore (Download)", func() {
 
 					r, err := zip.OpenReader(outputPath)
 					Expect(err).ToNot(HaveOccurred())
-    				defer r.Close()
+					defer r.Close()
 
 					found := false
 					for _, f := range r.File {


### PR DESCRIPTION
## Issue
When apps contain a watch app, their bundle name is selected for applying the Sina patch

Examples:
- Starbucks `com.starbucks.mystarbucks`
- Yelp `com.yelp.yelpiphone`

## Fix
Ignore app bundles that contain `/Watch/` in the path