### PR TITLE
Always apply user agent

### DIFF
--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -218,7 +218,6 @@ func (*appstore) downloadRequest(acc Account, app App, guid string) http.Request
 		Method:         http.MethodPOST,
 		ResponseFormat: http.ResponseFormatXML,
 		Headers: map[string]string{
-			"User-Agent":   "Configurator/2.15 (Macintosh; OperatingSystem X 11.0.0; 16G29) AppleWebKit/2603.3.8",
 			"Content-Type": "application/x-apple-plist",
 			"iCloud-DSID":  acc.DirectoryServicesID,
 			"X-Dsid":       acc.DirectoryServicesID,

--- a/pkg/appstore/appstore_login.go
+++ b/pkg/appstore/appstore_login.go
@@ -147,7 +147,6 @@ func (a *appstore) loginRequest(email, password, authCode, guid string) http.Req
 		URL:            a.authDomain(authCode, guid),
 		ResponseFormat: http.ResponseFormatXML,
 		Headers: map[string]string{
-			"User-Agent":   "Configurator/2.15 (Macintosh; OperatingSystem X 11.0.0; 16G29) AppleWebKit/2603.3.8",
 			"Content-Type": "application/x-www-form-urlencoded",
 		},
 		Payload: &http.XMLPayload{

--- a/pkg/appstore/appstore_purchase.go
+++ b/pkg/appstore/appstore_purchase.go
@@ -112,7 +112,6 @@ func (a *appstore) purchaseRequest(acc Account, app App, storeFront, guid string
 		Method:         http.MethodPOST,
 		ResponseFormat: http.ResponseFormatXML,
 		Headers: map[string]string{
-			"User-Agent":          "Configurator/2.15 (Macintosh; OperatingSystem X 11.0.0; 16G29) AppleWebKit/2603.3.8",
 			"Content-Type":        "application/x-apple-plist",
 			"iCloud-DSID":         acc.DirectoryServicesID,
 			"X-Dsid":              acc.DirectoryServicesID,

--- a/pkg/http/constants.go
+++ b/pkg/http/constants.go
@@ -5,4 +5,5 @@ type ResponseFormat string
 const (
 	ResponseFormatJSON ResponseFormat = "json"
 	ResponseFormatXML  ResponseFormat = "xml"
+	DefaultUserAgent                  = "Configurator/2.15 (Macintosh; OperatingSystem X 11.0.0; 16G29) AppleWebKit/2603.3.8"
 )


### PR DESCRIPTION
Makes all requests use a default user agent of Configurator, instead of Go's default user agent