### PR TITLE
Disable client timeout

### DIFF
--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"time"
 )
 
 //go:generate mockgen -source=client.go -destination=client_mock.go -package=http
@@ -41,7 +40,7 @@ func (adt *AddHeaderTransport) RoundTrip(req *http.Request) (*http.Response, err
 func NewClient[R interface{}](args ClientArgs) Client[R] {
 	return &client[R]{
 		internalClient: http.Client{
-			Timeout:   time.Second * 15,
+			Timeout:   0,
 			Jar:       args.CookieJar,
 			Transport: &AddHeaderTransport{http.DefaultTransport},
 		},


### PR DESCRIPTION
Having a client timeout of 15 seconds means that any IPA larger than that would fail to download. This limit is easily hit even at 1Gbit downlink. The DefaultTransport in Go already has sane connect, idle, handshake, keepalive timeouts, so IMO we can safely remove this one.