### PR TITLE
Add note about logging in and 2FA in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Global Flags:
 Use "ipatool auth [command] --help" for more information about a command.
 ```
 
+You may login with `ipatool auth login --email` followed by your iCloud email. It will then ask you to `enter 2FA code:`, if you don't get a 2FA alert, you can get a 2FA code by following the Apple guides for [Mac](https://support.apple.com/en-ie/guide/mac-help/mchl8bd4e9c2/mac) or [iOS](https://support.apple.com/en-us/HT204974).
+
 To search for apps on the App Store, use the `search` command.
 
 ```


### PR DESCRIPTION
When users are asked for the 2FA code upon authenticating with their Apple IDs, they expect to get an alert on at least one of their Apple devices. Sometimes they don't and don't know what to do like in this example: https://github.com/majd/ipatool/issues/132. Adding a note to links to the help pages for getting 2FA codes manually on Mac and iOS would be very helpful.