### PR TITLE
Add ability to download .ipa by the app ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,15 +107,17 @@ Usage:
   ipatool download [flags]
 
 Flags:
-  -b, --bundle-identifier string   The bundle identifier of the target iOS app (required)
+  -i, --app-id int                 ID of the target iOS app (required)
+  -b, --bundle-identifier string   The bundle identifier of the target iOS app (overrides the app ID)
   -h, --help                       help for download
   -o, --output string              The destination path of the downloaded app package
       --purchase                   Obtain a license for the app if needed
 
 Global Flags:
-      --format format     sets output format for command; can be 'text', 'json' (default text)
-      --non-interactive   run in non-interactive session
-      --verbose           enables verbose logs
+      --format format                sets output format for command; can be 'text', 'json' (default text)
+      --keychain-passphrase string   passphrase for unlocking keychain
+      --non-interactive              run in non-interactive session
+      --verbose                      enables verbose logs
 ```
 
 **Note:** the tool runs in interactive mode by default. Use the `--non-interactive` flag

--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/majd/ipatool/v2/pkg/http"
@@ -161,10 +162,18 @@ func (*appstore) downloadRequest(acc Account, app App, guid string) http.Request
 }
 
 func fileName(app App) string {
-	return fmt.Sprintf("%s_%d_%s.ipa",
-		app.BundleID,
-		app.ID,
-		app.Version)
+	var parts []string
+	if app.BundleID != "" {
+		parts = append(parts, app.BundleID)
+	}
+	if app.ID != 0 {
+		parts = append(parts, strconv.FormatInt(app.ID, 10))
+	}
+	if app.Version != "" {
+		parts = append(parts, app.Version)
+	}
+
+	return fmt.Sprintf("%s.ipa", strings.Join(parts, "_"))
 }
 
 func (t *appstore) resolveDestinationPath(app App, path string) (string, error) {

--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -163,12 +163,15 @@ func (*appstore) downloadRequest(acc Account, app App, guid string) http.Request
 
 func fileName(app App) string {
 	var parts []string
+
 	if app.BundleID != "" {
 		parts = append(parts, app.BundleID)
 	}
+
 	if app.ID != 0 {
 		parts = append(parts, strconv.FormatInt(app.ID, 10))
 	}
+
 	if app.Version != "" {
 		parts = append(parts, app.Version)
 	}


### PR DESCRIPTION
This PR allows to download some applications, unavailable to lookup by the bundle identifier, but still accessible for download by their ID.