### PR TITLE
fix authentication

### DIFF
--- a/pkg/http/constants.go
+++ b/pkg/http/constants.go
@@ -8,5 +8,5 @@ const (
 )
 
 const (
-	DefaultUserAgent = "Configurator/2.15 (Macintosh; OS X 11.0.0; 16G29) AppleWebKit/2603.3.8"
+	DefaultUserAgent = "Configurator/2.17 (Macintosh; OS X 15.2; 24C5089c) AppleWebKit/0620.1.16.11.6"
 )

--- a/pkg/http/result.go
+++ b/pkg/http/result.go
@@ -1,7 +1,26 @@
 package http
 
+import (
+	"errors"
+	"strings"
+)
+
+var (
+	ErrHeaderNotFound = errors.New("header not found")
+)
+
 type Result[R interface{}] struct {
 	StatusCode int
 	Headers    map[string]string
 	Data       R
+}
+
+func (c *Result[R]) GetHeader(key string) (string, error) {
+	key = strings.ToLower(key)
+	for k, v := range c.Headers {
+		if strings.ToLower(k) == key {
+			return v, nil
+		}
+	}
+	return "", ErrHeaderNotFound
 }


### PR DESCRIPTION
Apple has introduced some dynamic GET parameters into their redirects, forcing us to use the main domain ( no `p71-` and such prefixes ) to obtain those parameters.

However, when following such redirects, we shall also increment the `attempt` parameter ( something that was hard-coded before ).