### PR TITLE
Log if app purchase was required and executed

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -30,6 +30,7 @@ func downloadCmd() *cobra.Command {
 
 			var lastErr error
 			var acc appstore.Account
+			var purchased bool = false
 
 			return retry.Do(func() error {
 				infoResult, err := dependencies.AppStore.AccountInfo()
@@ -63,6 +64,10 @@ func downloadCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
+					purchased = true
+					dependencies.Logger.Verbose().
+						Bool("success", true).
+						Msg("purchase")
 				}
 
 				interactive, _ := cmd.Context().Value("interactive").(bool)
@@ -96,6 +101,7 @@ func downloadCmd() *cobra.Command {
 
 				dependencies.Logger.Log().
 					Str("output", out.DestinationPath).
+					Bool("purchased", purchased).
 					Bool("success", true).
 					Send()
 

--- a/pkg/appstore/constants.go
+++ b/pkg/appstore/constants.go
@@ -17,7 +17,7 @@ const (
 	PrivateAppStoreAPIDomainPrefixWithAuthCode    = "p71"
 	PrivateAppStoreAPIDomain                      = "buy." + iTunesAPIDomain
 	PrivateAppStoreAPIPathAuthenticate            = "/WebObjects/MZFinance.woa/wa/authenticate"
-	PrivateAppStoreAPIPathPurchase                = "/WebObjects/MZBuy.woa/wa/buyProduct"
+	PrivateAppStoreAPIPathPurchase                = "/WebObjects/MZFinance.woa/wa/buyProduct"
 	PrivateAppStoreAPIPathDownload                = "/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct"
 
 	HTTPHeaderStoreFront = "X-Set-Apple-Store-Front"


### PR DESCRIPTION
Integrate majd/ipatool#338 and add some logging to inform when we're purchasing an app during the download process.