### PR TITLE
Implement GetVersionMetadata command

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,19 +120,39 @@ Global Flags:
 
 To download a copy of the ipa file, use the `download` command.
 
-```
+````
 Download (encrypted) iOS app packages from the App Store
 
 Usage:
   ipatool download [flags]
 
 Flags:
-  -i, --app-id int                 ID of the target iOS app (required)
-  -b, --bundle-identifier string   The bundle identifier of the target iOS app (overrides the app ID)
-  -h, --help                       help for download
-  -o, --output string              The destination path of the downloaded app package
-      --purchase                   Obtain a license for the app if needed
-      --version string             Version of the app to download (defaults to latest version when not specified)
+  -i, --app-id int                   ID of the target iOS app (required)
+  -b, --bundle-identifier string     The bundle identifier of the target iOS app (overrides the app ID)
+      --external-version-id string   External version identifier of the target iOS app (defaults to latest version when not specified)
+  -h, --help                         help for download
+  -o, --output string                The destination path of the downloaded app package
+      --purchase                     Obtain a license for the app if needed
+
+Global Flags:
+      --format format                sets output format for command; can be 'text', 'json' (default text)
+      --keychain-passphrase string   passphrase for unlocking keychain
+      --non-interactive              run in non-interactive session
+      --verbose                      enables verbose logs
+```
+
+To resolve an external version identifier, returned by the `list-versions` command, use the `get-version-metadata` command.
+```
+Retrieves the metadata for a specific version of an app
+
+Usage:
+  ipatool get-version-metadata [flags]
+
+Flags:
+  -i, --app-id int                   ID of the target iOS app (required)
+  -b, --bundle-identifier string     The bundle identifier of the target iOS app (overrides the app ID)
+      --external-version-id string   External version identifier of the target iOS app (required)
+  -h, --help                         help for get-version-metadata
 
 Global Flags:
       --format format                sets output format for command; can be 'text', 'json' (default text)
@@ -150,7 +170,7 @@ The tool can be compiled using the Go toolchain.
 
 ```shell
 $ go build -o ipatool
-```
+````
 
 Unit tests can be executed with the following commands.
 

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -14,11 +14,11 @@ import (
 // nolint:wrapcheck
 func downloadCmd() *cobra.Command {
 	var (
-		acquireLicense bool
-		outputPath     string
-		appID          int64
-		bundleID       string
-		version        string
+		acquireLicense    bool
+		outputPath        string
+		appID             int64
+		bundleID          string
+		externalVersionID string
 	)
 
 	cmd := &cobra.Command{
@@ -91,7 +91,7 @@ func downloadCmd() *cobra.Command {
 				}
 
 				out, err := dependencies.AppStore.Download(appstore.DownloadInput{
-					Account: acc, App: app, OutputPath: outputPath, Progress: progress, Version: version})
+					Account: acc, App: app, OutputPath: outputPath, Progress: progress, ExternalVersionID: externalVersionID})
 				if err != nil {
 					return err
 				}
@@ -133,7 +133,7 @@ func downloadCmd() *cobra.Command {
 	cmd.Flags().Int64VarP(&appID, "app-id", "i", 0, "ID of the target iOS app (required)")
 	cmd.Flags().StringVarP(&bundleID, "bundle-identifier", "b", "", "The bundle identifier of the target iOS app (overrides the app ID)")
 	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "The destination path of the downloaded app package")
-	cmd.Flags().StringVar(&version, "version", "", "Version of the app to download (defaults to latest version when not specified)")
+	cmd.Flags().StringVar(&externalVersionID, "external-version-id", "", "External version identifier of the target iOS app (defaults to latest version when not specified)")
 	cmd.Flags().BoolVar(&acquireLicense, "purchase", false, "Obtain a license for the app if needed")
 
 	return cmd

--- a/cmd/get_version_metadata.go
+++ b/cmd/get_version_metadata.go
@@ -88,7 +88,9 @@ func getVersionMetadataCmd() *cobra.Command {
 
 	cmd.Flags().Int64VarP(&appID, "app-id", "i", 0, "ID of the target iOS app (required)")
 	cmd.Flags().StringVarP(&bundleID, "bundle-identifier", "b", "", "The bundle identifier of the target iOS app (overrides the app ID)")
-	cmd.Flags().StringVar(&externalVersionID, "external-version-id", "", "External version identifier of the target iOS app (defaults to latest version when not specified)")
+	cmd.Flags().StringVar(&externalVersionID, "external-version-id", "", "External version identifier of the target iOS app (required)")
+
+	_ = cmd.MarkFlagRequired("external-version-id")
 
 	return cmd
 }

--- a/cmd/get_version_metadata.go
+++ b/cmd/get_version_metadata.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"errors"
+	"time"
+
+	"github.com/avast/retry-go"
+	"github.com/majd/ipatool/v2/pkg/appstore"
+	"github.com/spf13/cobra"
+)
+
+// nolint:wrapcheck
+func getVersionMetadataCmd() *cobra.Command {
+	var (
+		appID             int64
+		bundleID          string
+		externalVersionID string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "get-version-metadata",
+		Short: "Retrieves the metadata for a specific version of an app",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if appID == 0 && bundleID == "" {
+				return errors.New("either the app ID or the bundle identifier must be specified")
+			}
+
+			var lastErr error
+			var acc appstore.Account
+
+			return retry.Do(func() error {
+				infoResult, err := dependencies.AppStore.AccountInfo()
+				if err != nil {
+					return err
+				}
+
+				acc = infoResult.Account
+
+				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
+					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{Email: acc.Email, Password: acc.Password})
+					if err != nil {
+						return err
+					}
+
+					acc = loginResult.Account
+				}
+
+				app := appstore.App{ID: appID}
+				if bundleID != "" {
+					lookupResult, err := dependencies.AppStore.Lookup(appstore.LookupInput{Account: acc, BundleID: bundleID})
+					if err != nil {
+						return err
+					}
+
+					app = lookupResult.App
+				}
+
+				out, err := dependencies.AppStore.GetVersionMetadata(appstore.GetVersionMetadataInput{
+					Account:   acc,
+					App:       app,
+					VersionID: externalVersionID,
+				})
+				if err != nil {
+					return err
+				}
+
+				dependencies.Logger.Log().
+					Str("externalVersionID", externalVersionID).
+					Str("displayVersion", out.DisplayVersion).
+					Time("releaseDate", out.ReleaseDate).
+					Bool("success", true).
+					Send()
+
+				return nil
+			},
+				retry.LastErrorOnly(true),
+				retry.DelayType(retry.FixedDelay),
+				retry.Delay(time.Millisecond),
+				retry.Attempts(2),
+				retry.RetryIf(func(err error) bool {
+					lastErr = err
+
+					return errors.Is(err, appstore.ErrPasswordTokenExpired)
+				}),
+			)
+		},
+	}
+
+	cmd.Flags().Int64VarP(&appID, "app-id", "i", 0, "ID of the target iOS app (required)")
+	cmd.Flags().StringVarP(&bundleID, "bundle-identifier", "b", "", "The bundle identifier of the target iOS app (overrides the app ID)")
+	cmd.Flags().StringVar(&externalVersionID, "external-version-id", "", "External version identifier of the target iOS app (defaults to latest version when not specified)")
+
+	return cmd
+}

--- a/cmd/list_versions.go
+++ b/cmd/list_versions.go
@@ -60,8 +60,7 @@ func ListVersionsCmd() *cobra.Command {
 				}
 
 				dependencies.Logger.Log().
-					Interface("versions", out.Versions).
-					Str("latestVersion", out.LatestVersion).
+					Interface("externalVersionIdentifiers", out.ExternalVersionIdentifiers).
 					Str("bundleID", app.BundleID).
 					Bool("success", true).
 					Send()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,7 @@ func rootCmd() *cobra.Command {
 	cmd.AddCommand(purchaseCmd())
 	cmd.AddCommand(searchCmd())
 	cmd.AddCommand(ListVersionsCmd())
+	cmd.AddCommand(getVersionMetadataCmd())
 
 	return cmd
 }

--- a/pkg/appstore/appstore.go
+++ b/pkg/appstore/appstore.go
@@ -27,6 +27,8 @@ type AppStore interface {
 	ReplicateSinf(input ReplicateSinfInput) error
 	// VersionHistory lists the available versions of the specified app.
 	ListVersions(input ListVersionsInput) (ListVersionsOutput, error)
+	// GetVersionMetadata returns the metadata for the specified version.
+	GetVersionMetadata(input GetVersionMetadataInput) (GetVersionMetadataOutput, error)
 }
 
 type appstore struct {

--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -19,11 +19,11 @@ var (
 )
 
 type DownloadInput struct {
-	Account    Account
-	App        App
-	OutputPath string
-	Progress   *progressbar.ProgressBar
-	Version    string
+	Account           Account
+	App               App
+	OutputPath        string
+	Progress          *progressbar.ProgressBar
+	ExternalVersionID string
 }
 
 type DownloadOutput struct {
@@ -39,7 +39,7 @@ func (t *appstore) Download(input DownloadInput) (DownloadOutput, error) {
 
 	guid := strings.ReplaceAll(strings.ToUpper(macAddr), ":", "")
 
-	req := t.downloadRequest(input.Account, input.App, guid, input.Version)
+	req := t.downloadRequest(input.Account, input.App, guid, input.ExternalVersionID)
 
 	res, err := t.downloadClient.Send(req)
 	if err != nil {
@@ -147,7 +147,7 @@ func (t *appstore) downloadFile(src, dst string, progress *progressbar.ProgressB
 	return nil
 }
 
-func (*appstore) downloadRequest(acc Account, app App, guid string, version string) http.Request {
+func (*appstore) downloadRequest(acc Account, app App, guid string, externalVersionID string) http.Request {
 	host := fmt.Sprintf("%s-%s", PrivateAppStoreAPIDomainPrefixWithoutAuthCode, PrivateAppStoreAPIDomain)
 
 	payload := map[string]interface{}{
@@ -156,8 +156,8 @@ func (*appstore) downloadRequest(acc Account, app App, guid string, version stri
 		"salableAdamId": app.ID,
 	}
 
-	if version != "" {
-		payload["externalVersionId"] = version
+	if externalVersionID != "" {
+		payload["externalVersionId"] = externalVersionID
 	}
 
 	return http.Request{

--- a/pkg/appstore/appstore_get_version_metadata.go
+++ b/pkg/appstore/appstore_get_version_metadata.go
@@ -57,8 +57,6 @@ func (t *appstore) GetVersionMetadata(input GetVersionMetadataInput) (GetVersion
 
 	item := res.Data.Items[0]
 
-	fmt.Printf("%+v\n", item)
-
 	releaseDate, err := time.Parse(time.RFC3339, fmt.Sprintf("%v", item.Metadata["releaseDate"]))
 	if err != nil {
 		return GetVersionMetadataOutput{}, fmt.Errorf("failed to parse release date: %w", err)

--- a/pkg/appstore/appstore_get_version_metadata.go
+++ b/pkg/appstore/appstore_get_version_metadata.go
@@ -1,0 +1,97 @@
+package appstore
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/majd/ipatool/v2/pkg/http"
+)
+
+type GetVersionMetadataInput struct {
+	Account   Account
+	App       App
+	VersionID string
+}
+
+type GetVersionMetadataOutput struct {
+	DisplayVersion string
+	ReleaseDate    time.Time
+}
+
+func (t *appstore) GetVersionMetadata(input GetVersionMetadataInput) (GetVersionMetadataOutput, error) {
+	macAddr, err := t.machine.MacAddress()
+	if err != nil {
+		return GetVersionMetadataOutput{}, fmt.Errorf("failed to get mac address: %w", err)
+	}
+
+	guid := strings.ReplaceAll(strings.ToUpper(macAddr), ":", "")
+
+	req := t.getVersionMetadataRequest(input.Account, input.App, guid, input.VersionID)
+	res, err := t.downloadClient.Send(req)
+
+	if err != nil {
+		return GetVersionMetadataOutput{}, fmt.Errorf("failed to send http request: %w", err)
+	}
+
+	if res.Data.FailureType == FailureTypePasswordTokenExpired {
+		return GetVersionMetadataOutput{}, ErrPasswordTokenExpired
+	}
+
+	if res.Data.FailureType == FailureTypeLicenseNotFound {
+		return GetVersionMetadataOutput{}, ErrLicenseRequired
+	}
+
+	if res.Data.FailureType != "" && res.Data.CustomerMessage != "" {
+		return GetVersionMetadataOutput{}, NewErrorWithMetadata(fmt.Errorf("received error: %s", res.Data.CustomerMessage), res)
+	}
+
+	if res.Data.FailureType != "" {
+		return GetVersionMetadataOutput{}, NewErrorWithMetadata(fmt.Errorf("received error: %s", res.Data.FailureType), res)
+	}
+
+	if len(res.Data.Items) == 0 {
+		return GetVersionMetadataOutput{}, NewErrorWithMetadata(errors.New("invalid response"), res)
+	}
+
+	item := res.Data.Items[0]
+
+	fmt.Printf("%+v\n", item)
+
+	releaseDate, err := time.Parse(time.RFC3339, fmt.Sprintf("%v", item.Metadata["releaseDate"]))
+	if err != nil {
+		return GetVersionMetadataOutput{}, fmt.Errorf("failed to parse release date: %w", err)
+	}
+
+	return GetVersionMetadataOutput{
+		DisplayVersion: fmt.Sprintf("%v", item.Metadata["bundleShortVersionString"]),
+		ReleaseDate:    releaseDate,
+	}, nil
+
+}
+
+func (t *appstore) getVersionMetadataRequest(acc Account, app App, guid string, version string) http.Request {
+	host := fmt.Sprintf("%s-%s", PrivateAppStoreAPIDomainPrefixWithoutAuthCode, PrivateAppStoreAPIDomain)
+
+	payload := map[string]interface{}{
+		"creditDisplay":     "",
+		"guid":              guid,
+		"salableAdamId":     app.ID,
+		"externalVersionId": version,
+	}
+
+	return http.Request{
+		URL:            fmt.Sprintf("https://%s%s?guid=%s", host, PrivateAppStoreAPIPathDownload, guid),
+		Method:         http.MethodPOST,
+		ResponseFormat: http.ResponseFormatXML,
+		Headers: map[string]string{
+			"Content-Type": "application/x-apple-plist",
+			"iCloud-DSID":  acc.DirectoryServicesID,
+			"X-Dsid":       acc.DirectoryServicesID,
+		},
+		Payload: &http.XMLPayload{
+			Content: payload,
+		},
+	}
+}

--- a/pkg/appstore/appstore_get_version_metadata.go
+++ b/pkg/appstore/appstore_get_version_metadata.go
@@ -66,7 +66,6 @@ func (t *appstore) GetVersionMetadata(input GetVersionMetadataInput) (GetVersion
 		DisplayVersion: fmt.Sprintf("%v", item.Metadata["bundleShortVersionString"]),
 		ReleaseDate:    releaseDate,
 	}, nil
-
 }
 
 func (t *appstore) getVersionMetadataRequest(acc Account, app App, guid string, version string) http.Request {

--- a/pkg/appstore/appstore_get_version_metadata_test.go
+++ b/pkg/appstore/appstore_get_version_metadata_test.go
@@ -1,0 +1,243 @@
+package appstore
+
+import (
+	"errors"
+	"time"
+
+	"github.com/majd/ipatool/v2/pkg/http"
+	"github.com/majd/ipatool/v2/pkg/util/machine"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+)
+
+var _ = Describe("AppStore (GetVersionMetadata)", func() {
+	var (
+		ctrl               *gomock.Controller
+		mockMachine        *machine.MockMachine
+		mockDownloadClient *http.MockClient[downloadResult]
+		as                 AppStore
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockMachine = machine.NewMockMachine(ctrl)
+		mockDownloadClient = http.NewMockClient[downloadResult](ctrl)
+		as = &appstore{
+			machine:        mockMachine,
+			downloadClient: mockDownloadClient,
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	When("fails to get MAC address", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("", errors.New("mac error"))
+		})
+
+		It("returns error", func() {
+			_, err := as.GetVersionMetadata(GetVersionMetadataInput{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get mac address"))
+		})
+	})
+
+	When("request fails", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			mockDownloadClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[downloadResult]{}, errors.New("request error"))
+		})
+
+		It("returns error", func() {
+			_, err := as.GetVersionMetadata(GetVersionMetadataInput{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to send http request"))
+		})
+	})
+
+	When("password token is expired", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			mockDownloadClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[downloadResult]{
+					Data: downloadResult{
+						FailureType: FailureTypePasswordTokenExpired,
+					},
+				}, nil)
+		})
+
+		It("returns error", func() {
+			_, err := as.GetVersionMetadata(GetVersionMetadataInput{})
+			Expect(err).To(Equal(ErrPasswordTokenExpired))
+		})
+	})
+
+	When("license is missing", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			mockDownloadClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[downloadResult]{
+					Data: downloadResult{
+						FailureType: FailureTypeLicenseNotFound,
+					},
+				}, nil)
+		})
+
+		It("returns error", func() {
+			_, err := as.GetVersionMetadata(GetVersionMetadataInput{})
+			Expect(err).To(Equal(ErrLicenseRequired))
+		})
+	})
+
+	When("store API returns error", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+		})
+
+		When("response contains customer message", func() {
+			BeforeEach(func() {
+				mockDownloadClient.EXPECT().
+					Send(gomock.Any()).
+					Return(http.Result[downloadResult]{
+						Data: downloadResult{
+							FailureType:     "SOME_ERROR",
+							CustomerMessage: "Customer error message",
+						},
+					}, nil)
+			})
+
+			It("returns customer message as error", func() {
+				_, err := as.GetVersionMetadata(GetVersionMetadataInput{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Customer error message"))
+			})
+		})
+
+		When("response does not contain customer message", func() {
+			BeforeEach(func() {
+				mockDownloadClient.EXPECT().
+					Send(gomock.Any()).
+					Return(http.Result[downloadResult]{
+						Data: downloadResult{
+							FailureType: "SOME_ERROR",
+						},
+					}, nil)
+			})
+
+			It("returns generic error", func() {
+				_, err := as.GetVersionMetadata(GetVersionMetadataInput{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("SOME_ERROR"))
+			})
+		})
+	})
+
+	When("store API returns no items", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			mockDownloadClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[downloadResult]{
+					Data: downloadResult{
+						Items: []downloadItemResult{},
+					},
+				}, nil)
+		})
+
+		It("returns error", func() {
+			_, err := as.GetVersionMetadata(GetVersionMetadataInput{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid response"))
+		})
+	})
+
+	When("fails to parse release date", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			mockDownloadClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[downloadResult]{
+					Data: downloadResult{
+						Items: []downloadItemResult{
+							{
+								Metadata: map[string]interface{}{
+									"releaseDate": "invalid-date",
+								},
+							},
+						},
+					},
+				}, nil)
+		})
+
+		It("returns error", func() {
+			_, err := as.GetVersionMetadata(GetVersionMetadataInput{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to parse release date"))
+		})
+	})
+
+	When("successfully gets version metadata", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			mockDownloadClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[downloadResult]{
+					Data: downloadResult{
+						Items: []downloadItemResult{
+							{
+								Metadata: map[string]interface{}{
+									"releaseDate":              "2024-03-20T12:00:00Z",
+									"bundleShortVersionString": "1.0.0",
+								},
+							},
+						},
+					},
+				}, nil)
+		})
+
+		It("returns version metadata", func() {
+			output, err := as.GetVersionMetadata(GetVersionMetadataInput{
+				Account: Account{
+					DirectoryServicesID: "test-dsid",
+				},
+				App: App{
+					ID: 1234567890,
+				},
+				VersionID: "test-version",
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output.DisplayVersion).To(Equal("1.0.0"))
+			Expect(output.ReleaseDate).To(Equal(time.Date(2024, 3, 20, 12, 0, 0, 0, time.UTC)))
+		})
+	})
+})

--- a/pkg/appstore/appstore_list_versions.go
+++ b/pkg/appstore/appstore_list_versions.go
@@ -14,8 +14,8 @@ type ListVersionsInput struct {
 }
 
 type ListVersionsOutput struct {
-	Versions      []string
-	LatestVersion string
+	ExternalVersionIdentifiers []string
+	LatestExternalVersionID    string
 }
 
 func (t *appstore) ListVersions(input ListVersionsInput) (ListVersionsOutput, error) {
@@ -60,19 +60,19 @@ func (t *appstore) ListVersions(input ListVersionsInput) (ListVersionsOutput, er
 		return ListVersionsOutput{}, NewErrorWithMetadata(fmt.Errorf("failed to get version identifiers from item metadata"), item.Metadata)
 	}
 
-	versions := make([]string, len(rawIdentifiers))
+	externalVersionIdentifiers := make([]string, len(rawIdentifiers))
 	for i, val := range rawIdentifiers {
-		versions[i] = fmt.Sprintf("%v", val)
+		externalVersionIdentifiers[i] = fmt.Sprintf("%v", val)
 	}
 
-	latestVersionRaw := item.Metadata["softwareVersionExternalIdentifier"]
-	if latestVersionRaw == nil {
+	latestExternalVersionID := item.Metadata["softwareVersionExternalIdentifier"]
+	if latestExternalVersionID == nil {
 		return ListVersionsOutput{}, NewErrorWithMetadata(fmt.Errorf("failed to get latest version from item metadata"), item.Metadata)
 	}
 
 	return ListVersionsOutput{
-		Versions:      versions,
-		LatestVersion: fmt.Sprintf("%v", latestVersionRaw),
+		ExternalVersionIdentifiers: externalVersionIdentifiers,
+		LatestExternalVersionID:    fmt.Sprintf("%v", latestExternalVersionID),
 	}, nil
 }
 

--- a/pkg/appstore/appstore_list_versions_test.go
+++ b/pkg/appstore/appstore_list_versions_test.go
@@ -257,8 +257,8 @@ var _ = Describe("AppStore (ListVersions)", func() {
 		It("returns versions", func() {
 			out, err := as.ListVersions(ListVersionsInput{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(out.Versions).To(Equal([]string{testVersion1, testVersion2}))
-			Expect(out.LatestVersion).To(Equal(testLatest))
+			Expect(out.ExternalVersionIdentifiers).To(Equal([]string{testVersion1, testVersion2}))
+			Expect(out.LatestExternalVersionID).To(Equal(testLatest))
 		})
 	})
 })

--- a/pkg/appstore/appstore_login.go
+++ b/pkg/appstore/appstore_login.go
@@ -90,7 +90,7 @@ func (t *appstore) login(email, password, authCode, guid string) (Account, error
 		return Account{}, NewErrorWithMetadata(errors.New("too many attempts"), res)
 	}
 
-	sf, err := res.GetHeader(HTTPHeaderStoreFront)
+	storeFront, err := res.GetHeader(HTTPHeaderStoreFront)
 	if err != nil {
 		return Account{}, NewErrorWithMetadata(fmt.Errorf("failed to get storefront header: %w", err), res)
 	}
@@ -101,7 +101,7 @@ func (t *appstore) login(email, password, authCode, guid string) (Account, error
 		Email:               res.Data.Account.Email,
 		PasswordToken:       res.Data.PasswordToken,
 		DirectoryServicesID: res.Data.DirectoryServicesID,
-		StoreFront:          sf,
+		StoreFront:          storeFront,
 		Password:            password,
 	}
 

--- a/pkg/appstore/storefront.go
+++ b/pkg/appstore/storefront.go
@@ -14,10 +14,6 @@ func countryCodeFromStoreFront(storeFront string) (string, error) {
 		}
 	}
 
-	if storeFront == "" {
-		return "", nil
-	}
-
 	return "", fmt.Errorf("country code mapping for store front (%s) was not found", storeFront)
 }
 


### PR DESCRIPTION
This PR implements the `get-version-metadata` CLI command that can be used to resolve an external version identifier to the display version of an app.