### PR TITLE
Fix accidental append if file already exist

### DIFF
--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -126,7 +126,7 @@ func (t *appstore) downloadFile(src, dst string, progress *progressbar.ProgressB
 	}
 	defer res.Body.Close()
 
-	file, err := t.os.OpenFile(dst, os.O_CREATE|os.O_WRONLY, 0644)
+	file, err := t.os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open file: %w", err)
 	}
@@ -237,7 +237,7 @@ func (t *appstore) applyPatches(item downloadItemResult, acc Account, src, dst s
 	}
 	defer srcZip.Close()
 
-	dstFile, err := t.os.OpenFile(dst, os.O_CREATE|os.O_WRONLY, 0644)
+	dstFile, err := t.os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open file: %w", err)
 	}

--- a/pkg/appstore/appstore_download_test.go
+++ b/pkg/appstore/appstore_download_test.go
@@ -388,7 +388,7 @@ var _ = Describe("AppStore (Download)", func() {
 
 			BeforeEach(func() {
 				var err error
-				tmpFile, err = os.OpenFile(fmt.Sprintf("%s.tmp", testFile.Name()), os.O_CREATE|os.O_WRONLY, 0644)
+				tmpFile, err = os.OpenFile(fmt.Sprintf("%s.tmp", testFile.Name()), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 				Expect(err).ToNot(HaveOccurred())
 
 				outputPath = strings.TrimSuffix(tmpFile.Name(), ".tmp")

--- a/pkg/appstore/appstore_replicate_sinf.go
+++ b/pkg/appstore/appstore_replicate_sinf.go
@@ -27,11 +27,11 @@ type ReplicateSinfInput struct {
 func (t *appstore) ReplicateSinf(input ReplicateSinfInput) error {
 	zipReader, err := zip.OpenReader(input.PackagePath)
 	if err != nil {
-		return errors.New("failed to open zip reader")
+		return fmt.Errorf("failed to open zip reader: %w", err)
 	}
 
 	tmpPath := fmt.Sprintf("%s.tmp", input.PackagePath)
-	tmpFile, err := t.os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY, 0644)
+	tmpFile, err := t.os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 
 	if err != nil {
 		return fmt.Errorf("failed to open file: %w", err)


### PR DESCRIPTION
Results in "failed to open zip reader".