### PR TITLE
Support batch version metadata retrieval via get-version-metadata --all-versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ Global Flags:
       --verbose                      enables verbose logs
 ```
 
+When using `--all-versions`, the command fires one request per version identifier against Apple’s private APIs. To avoid risking your main Apple Account, run this mode with a secondary account.
+
 **Note:** the tool runs in interactive mode by default. Use the `--non-interactive` flag
 if running in an automated environment.
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ Usage:
 Flags:
   -i, --app-id int                   ID of the target iOS app (required)
   -b, --bundle-identifier string     The bundle identifier of the target iOS app (overrides the app ID)
-      --external-version-id string   External version identifier of the target iOS app (required)
+      --all-versions                 Retrieve metadata for all available versions
+      --external-version-id string   External version identifier of the target iOS app
   -h, --help                         help for get-version-metadata
 
 Global Flags:

--- a/cmd/get_version_metadata.go
+++ b/cmd/get_version_metadata.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -15,6 +16,7 @@ func getVersionMetadataCmd() *cobra.Command {
 		appID             int64
 		bundleID          string
 		externalVersionID string
+		allVersions       bool
 	)
 
 	cmd := &cobra.Command{
@@ -23,6 +25,14 @@ func getVersionMetadataCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if appID == 0 && bundleID == "" {
 				return errors.New("either the app ID or the bundle identifier must be specified")
+			}
+
+			if !allVersions && externalVersionID == "" {
+				return errors.New("either the external version identifier must be specified or the --all-versions flag must be used")
+			}
+
+			if allVersions && externalVersionID != "" {
+				return errors.New("the --all-versions flag cannot be used together with the --external-version-id flag")
 			}
 
 			var lastErr error
@@ -53,6 +63,55 @@ func getVersionMetadataCmd() *cobra.Command {
 					}
 
 					app = lookupResult.App
+				}
+
+				if allVersions {
+					versions, err := dependencies.AppStore.ListVersions(appstore.ListVersionsInput{Account: acc, App: app})
+					if err != nil {
+						return err
+					}
+
+					versionDetails := make([]map[string]interface{}, 0, len(versions.ExternalVersionIdentifiers))
+					hasFailure := false
+					failureCount := 0
+					verboseMode := cmd.Flag("verbose").Value.String() == "true"
+
+					for _, versionID := range versions.ExternalVersionIdentifiers {
+						entry := map[string]interface{}{
+							"externalVersionID": versionID,
+						}
+
+						meta, err := dependencies.AppStore.GetVersionMetadata(appstore.GetVersionMetadataInput{
+							Account:   acc,
+							App:       app,
+							VersionID: versionID,
+						})
+						if err != nil {
+							hasFailure = true
+							failureCount++
+							entry["success"] = false
+							if verboseMode {
+								entry["error"] = err.Error()
+							}
+						} else {
+							entry["displayVersion"] = meta.DisplayVersion
+							entry["success"] = true
+						}
+
+						versionDetails = append(versionDetails, entry)
+					}
+
+					dependencies.Logger.Log().
+						Str("bundleID", app.BundleID).
+						Interface("versions", versionDetails).
+						Bool("success", !hasFailure).
+						Send()
+
+					if hasFailure {
+						return fmt.Errorf("failed to resolve metadata for %d version(s)", failureCount)
+					}
+
+					return nil
 				}
 
 				out, err := dependencies.AppStore.GetVersionMetadata(appstore.GetVersionMetadataInput{
@@ -88,9 +147,8 @@ func getVersionMetadataCmd() *cobra.Command {
 
 	cmd.Flags().Int64VarP(&appID, "app-id", "i", 0, "ID of the target iOS app (required)")
 	cmd.Flags().StringVarP(&bundleID, "bundle-identifier", "b", "", "The bundle identifier of the target iOS app (overrides the app ID)")
-	cmd.Flags().StringVar(&externalVersionID, "external-version-id", "", "External version identifier of the target iOS app (required)")
-
-	_ = cmd.MarkFlagRequired("external-version-id")
+	cmd.Flags().StringVar(&externalVersionID, "external-version-id", "", "External version identifier of the target iOS app")
+	cmd.Flags().BoolVar(&allVersions, "all-versions", false, "Retrieve metadata for all available versions")
 
 	return cmd
 }


### PR DESCRIPTION
  - Adds a new --all-versions workflow to get-version-metadata, letting users fetch every human-readable display version in one run instead of looping through external version IDs manually; the original single-ID path still works unchanged.
- Batch mode records {externalVersionID, displayVersion, success} for each lookup, only attaches error details when --verbose isenabled, and returns a non-zero exit if any version fails so callers can spot partial results.
- Updates the README to document both flag behaviors and note that the bulk mode hits private endpoints per version, suggesting a secondary Apple Account for anyone worried about account safety.