### PR TITLE
'ipatool auth reauth' command that refreshes the expired cookie

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -24,6 +24,7 @@ func authCmd() *cobra.Command {
 	cmd.AddCommand(loginCmd())
 	cmd.AddCommand(infoCmd())
 	cmd.AddCommand(revokeCmd())
+	cmd.AddCommand(reauthCmd())
 
 	return cmd
 }
@@ -144,6 +145,50 @@ func infoCmd() *cobra.Command {
 				Str("email", output.Account.Email).
 				Bool("success", true).
 				Send()
+
+			return nil
+		},
+	}
+}
+
+func reauthCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "reauth",
+		Short: "Attempt re-signin into iTunes Store (if the login had expired)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			interactive := cmd.Context().Value("interactive").(bool)
+
+			output0, err0 := dependencies.AppStore.AccountInfo()
+			if err0 != nil {
+				return err0
+			}
+
+			// dependencies.Logger.Log().
+			// 	Str("name", output0.Account.Name).
+			// 	Str("email", output0.Account.Email).
+			// 	Bool("success", true).
+			// 	Send()
+
+			output, err := dependencies.AppStore.Login(appstore.LoginInput{
+				Email:    output0.Account.Email,
+				Password: output0.Account.Password,
+				AuthCode: "",
+			})
+			if err != nil {
+				if errors.Is(err, appstore.ErrAuthCodeRequired) && !interactive {
+					dependencies.Logger.Log().Msg("2FA code is required; run the command again and supply a code using the `--auth-code` flag")
+
+					return nil
+				}
+
+				return err
+			}
+
+			dependencies.Logger.Log().
+					Str("name", output.Account.Name).
+					Str("email", output.Account.Email).
+					Bool("success", true).
+					Send()
 
 			return nil
 		},


### PR DESCRIPTION
From time to time cookies expire, and `ipatool download` returns an error "Sign in into the iTunes Store". This requires the user to manually invoke `ipatool auth -e "user@email.com"` and enter password. This step doesn't require 2FA.
Note that there is a keychain application password entry `ipatool-auth.service` that contains both email and password.
This PR introduces an `ipatool auth reauth` that just takes these email and password and performs Login, so the cookies file is re-created.

This command can help if ipatool is invoked automatically from an automated script and the login expiration can be annoying.

Ideally such reauthentication should happen automatically though