### PR TITLE
Updated README with dumber auth instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ $ brew install ipatool
 
 To authenticate with the App Store, use the `auth` command.
 
+> If you're logging in for the first time:
+>
+> ```
+> ipatool auth login -e APPLE_ID_EMAIL -p APPLE_ID_PASSWORD
+> ```
+>
+> 2FA is supported, but no specific error message is thrown if username/password are invalid.
+
 ```
 Authenticate with the App Store
 


### PR DESCRIPTION
Accepts request made in #245, #293 and #128.

Took me a stupid amount of time to figure out too, because entering an invalid email/password fails silently.