### PR TITLE
Treating 'iTunes Store Sign-in required' the same way as expired pass

### DIFF
--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -46,8 +46,7 @@ func (t *appstore) Download(input DownloadInput) (DownloadOutput, error) {
 		return DownloadOutput{}, fmt.Errorf("failed to send http request: %w", err)
 	}
 
-	if (res.Data.FailureType == FailureTypePasswordTokenExpired ||
-	   res.Data.FailureType == FailureTypeSignInRequired) {
+	if res.Data.FailureType == FailureTypePasswordTokenExpired || res.Data.FailureType == FailureTypeSignInRequired {
 		return DownloadOutput{}, ErrPasswordTokenExpired
 	}
 

--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -46,7 +46,8 @@ func (t *appstore) Download(input DownloadInput) (DownloadOutput, error) {
 		return DownloadOutput{}, fmt.Errorf("failed to send http request: %w", err)
 	}
 
-	if res.Data.FailureType == FailureTypePasswordTokenExpired {
+	if (res.Data.FailureType == FailureTypePasswordTokenExpired ||
+	   res.Data.FailureType == FailureTypeSignInRequired) {
 		return DownloadOutput{}, ErrPasswordTokenExpired
 	}
 

--- a/pkg/appstore/appstore_download_test.go
+++ b/pkg/appstore/appstore_download_test.go
@@ -148,6 +148,27 @@ var _ = Describe("AppStore (Download)", func() {
 		})
 	})
 
+	When("Sign In to the iTunes Store", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("", nil)
+
+			mockDownloadClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[downloadResult]{
+					Data: downloadResult{
+						FailureType: FailureTypeSignInRequired,
+					},
+				}, nil)
+		})
+
+		It("returns error", func() {
+			_, err := as.Download(DownloadInput{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	When("license is missing", func() {
 		BeforeEach(func() {
 			mockMachine.EXPECT().

--- a/pkg/appstore/appstore_get_version_metadata.go
+++ b/pkg/appstore/appstore_get_version_metadata.go
@@ -35,8 +35,7 @@ func (t *appstore) GetVersionMetadata(input GetVersionMetadataInput) (GetVersion
 		return GetVersionMetadataOutput{}, fmt.Errorf("failed to send http request: %w", err)
 	}
 
-	if (res.Data.FailureType == FailureTypePasswordTokenExpired ||
-	   res.Data.FailureType == FailureTypeSignInRequired) {
+	if res.Data.FailureType == FailureTypePasswordTokenExpired || res.Data.FailureType == FailureTypeSignInRequired {
 		return GetVersionMetadataOutput{}, ErrPasswordTokenExpired
 	}
 

--- a/pkg/appstore/appstore_get_version_metadata.go
+++ b/pkg/appstore/appstore_get_version_metadata.go
@@ -35,7 +35,8 @@ func (t *appstore) GetVersionMetadata(input GetVersionMetadataInput) (GetVersion
 		return GetVersionMetadataOutput{}, fmt.Errorf("failed to send http request: %w", err)
 	}
 
-	if res.Data.FailureType == FailureTypePasswordTokenExpired {
+	if (res.Data.FailureType == FailureTypePasswordTokenExpired ||
+	   res.Data.FailureType == FailureTypeSignInRequired) {
 		return GetVersionMetadataOutput{}, ErrPasswordTokenExpired
 	}
 

--- a/pkg/appstore/appstore_get_version_metadata_test.go
+++ b/pkg/appstore/appstore_get_version_metadata_test.go
@@ -117,6 +117,27 @@ var _ = Describe("AppStore (GetVersionMetadata)", func() {
 		})
 	})
 
+	When("Sign In to the iTunes Store", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			mockDownloadClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[downloadResult]{
+					Data: downloadResult{
+						FailureType: FailureTypeSignInRequired,
+					},
+				}, nil)
+		})
+
+		It("returns error", func() {
+			_, err := as.GetVersionMetadata(GetVersionMetadataInput{})
+			Expect(err).To(Equal(ErrPasswordTokenExpired))
+		})
+	})
+
 	When("license is missing", func() {
 		BeforeEach(func() {
 			mockMachine.EXPECT().

--- a/pkg/appstore/appstore_list_versions.go
+++ b/pkg/appstore/appstore_list_versions.go
@@ -33,7 +33,8 @@ func (t *appstore) ListVersions(input ListVersionsInput) (ListVersionsOutput, er
 		return ListVersionsOutput{}, fmt.Errorf("failed to send http request: %w", err)
 	}
 
-	if res.Data.FailureType == FailureTypePasswordTokenExpired {
+	if (res.Data.FailureType == FailureTypePasswordTokenExpired ||
+	   res.Data.FailureType == FailureTypeSignInRequired) {
 		return ListVersionsOutput{}, ErrPasswordTokenExpired
 	}
 

--- a/pkg/appstore/appstore_list_versions.go
+++ b/pkg/appstore/appstore_list_versions.go
@@ -33,8 +33,7 @@ func (t *appstore) ListVersions(input ListVersionsInput) (ListVersionsOutput, er
 		return ListVersionsOutput{}, fmt.Errorf("failed to send http request: %w", err)
 	}
 
-	if (res.Data.FailureType == FailureTypePasswordTokenExpired ||
-	   res.Data.FailureType == FailureTypeSignInRequired) {
+	if res.Data.FailureType == FailureTypePasswordTokenExpired || res.Data.FailureType == FailureTypeSignInRequired {
 		return ListVersionsOutput{}, ErrPasswordTokenExpired
 	}
 

--- a/pkg/appstore/appstore_list_versions_test.go
+++ b/pkg/appstore/appstore_list_versions_test.go
@@ -113,6 +113,27 @@ var _ = Describe("AppStore (ListVersions)", func() {
 		})
 	})
 
+	When("Sign In to the iTunes Store", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:00:00:00:00:00", nil)
+
+			mockDownloadClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[downloadResult]{
+					Data: downloadResult{
+						FailureType: FailureTypeSignInRequired,
+					},
+				}, nil)
+		})
+
+		It("returns error", func() {
+			_, err := as.ListVersions(ListVersionsInput{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	When("license is required", func() {
 		BeforeEach(func() {
 			mockMachine.EXPECT().

--- a/pkg/appstore/appstore_purchase.go
+++ b/pkg/appstore/appstore_purchase.go
@@ -72,7 +72,8 @@ func (t *appstore) purchaseWithParams(acc Account, app App, guid string, pricing
 		return ErrSubscriptionRequired
 	}
 
-	if res.Data.FailureType == FailureTypePasswordTokenExpired {
+	if (res.Data.FailureType == FailureTypePasswordTokenExpired ||
+	   res.Data.FailureType == FailureTypeSignInRequired) {
 		return ErrPasswordTokenExpired
 	}
 

--- a/pkg/appstore/appstore_purchase.go
+++ b/pkg/appstore/appstore_purchase.go
@@ -72,8 +72,7 @@ func (t *appstore) purchaseWithParams(acc Account, app App, guid string, pricing
 		return ErrSubscriptionRequired
 	}
 
-	if (res.Data.FailureType == FailureTypePasswordTokenExpired ||
-	   res.Data.FailureType == FailureTypeSignInRequired) {
+	if res.Data.FailureType == FailureTypePasswordTokenExpired || res.Data.FailureType == FailureTypeSignInRequired {
 		return ErrPasswordTokenExpired
 	}
 

--- a/pkg/appstore/appstore_purchase_test.go
+++ b/pkg/appstore/appstore_purchase_test.go
@@ -152,6 +152,31 @@ var _ = Describe("AppStore (Purchase)", func() {
 		})
 	})
 
+	When("Sign In to the iTunes Store", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:00:00:00:00:00", nil)
+
+			mockPurchaseClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[purchaseResult]{
+					Data: purchaseResult{
+						FailureType: FailureTypeSignInRequired,
+					},
+				}, nil)
+		})
+
+		It("returns error", func() {
+			err := as.Purchase(PurchaseInput{
+				Account: Account{
+					StoreFront: "143441",
+				},
+			})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	When("store API returns customer error message", func() {
 		BeforeEach(func() {
 			mockMachine.EXPECT().

--- a/pkg/appstore/constants.go
+++ b/pkg/appstore/constants.go
@@ -4,7 +4,6 @@ const (
 	FailureTypeInvalidCredentials     = "-5000"
 	FailureTypePasswordTokenExpired   = "2034"
 	FailureTypeSignInRequired         = "2042"
-
 	FailureTypeLicenseNotFound        = "9610"
 	FailureTypeTemporarilyUnavailable = "2059"
 

--- a/pkg/appstore/constants.go
+++ b/pkg/appstore/constants.go
@@ -3,6 +3,8 @@ package appstore
 const (
 	FailureTypeInvalidCredentials     = "-5000"
 	FailureTypePasswordTokenExpired   = "2034"
+	FailureTypeSignInRequired         = "2042"
+
 	FailureTypeLicenseNotFound        = "9610"
 	FailureTypeTemporarilyUnavailable = "2059"
 


### PR DESCRIPTION
In case the ipatool hadn't been used for some days, upon a bundle download attempt it returns an error `Sign In to the iTunes Store` with error code `2042`.

The tool currently attempts to re-login automatically only if the `2034` (`FailureTypePasswordTokenExpired`) code is returned, but for the error 2042 it just fails.

This PR adds handling of the `2042` error to the tool similar to how `2034` is handled. 
Such auto-login doesn't require 2FA.