### PR TITLE
Fix IPA generated by ipatool not installable via itms-services

### DIFF
--- a/pkg/appstore/appstore_replicate_sinf.go
+++ b/pkg/appstore/appstore_replicate_sinf.go
@@ -135,16 +135,16 @@ func (t *appstore) replicateSinfFromInfo(info packageInfo, zip *zip.Writer, sinf
 
 func (t *appstore) replicateZip(src *zip.ReadCloser, dst *zip.Writer) error {
 	for _, file := range src.File {
-		srcFile, err := file.OpenRaw()
+		srcFile, err := file.Open()
 		if err != nil {
-			return fmt.Errorf("failed to open raw file: %w", err)
+			return fmt.Errorf("failed to open file: %w", err)
 		}
 
 		header := file.FileHeader
-		dstFile, err := dst.CreateRaw(&header)
+		dstFile, err := dst.CreateHeader(&header)
 
 		if err != nil {
-			return fmt.Errorf("failed to create raw file: %w", err)
+			return fmt.Errorf("failed to create file: %w", err)
 		}
 
 		_, err = io.Copy(dstFile, srcFile)


### PR DESCRIPTION
This PR fixes an issue where IPA files generated by ipatool can be installed via Xcode,
but fail when installed through the `itms-services` protocol.

The installation failure was caused by the generated IPA not being compatible with
iOS streaming unzip (StreamingUnzip), which is required by itms-services installation.

Fixes #433

---