### PR TITLE
Resolve auth endpoint dynamically and use dedicated pods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .vscode/
 .idea/
 **/*_mock.go
+exp/

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -83,10 +83,16 @@ func loginCmd() *cobra.Command {
 					Str("authCode", util.IfEmpty(authCode, "<nil>")).
 					Msg("logging in")
 
+				bag, err := dependencies.AppStore.Bag(appstore.BagInput{})
+				if err != nil {
+					return fmt.Errorf("failed to get bag: %w", err)
+				}
+
 				output, err := dependencies.AppStore.Login(appstore.LoginInput{
 					Email:    email,
 					Password: password,
 					AuthCode: authCode,
+					Endpoint: bag.AuthEndpoint,
 				})
 				if err != nil {
 					if errors.Is(err, appstore.ErrAuthCodeRequired) && !interactive {

--- a/pkg/appstore/account.go
+++ b/pkg/appstore/account.go
@@ -7,4 +7,5 @@ type Account struct {
 	Name                string `json:"name,omitempty"`
 	StoreFront          string `json:"storeFront,omitempty"`
 	Password            string `json:"password,omitempty"`
+	Pod                 string `json:"pod,omitempty"`
 }

--- a/pkg/appstore/appstore.go
+++ b/pkg/appstore/appstore.go
@@ -29,6 +29,8 @@ type AppStore interface {
 	ListVersions(input ListVersionsInput) (ListVersionsOutput, error)
 	// GetVersionMetadata returns the metadata for the specified version.
 	GetVersionMetadata(input GetVersionMetadataInput) (GetVersionMetadataOutput, error)
+	// Bag fetches the bag which contains endpoint definitions.
+	Bag(input BagInput) (BagOutput, error)
 }
 
 type appstore struct {
@@ -37,6 +39,7 @@ type appstore struct {
 	searchClient   http.Client[searchResult]
 	purchaseClient http.Client[purchaseResult]
 	downloadClient http.Client[downloadResult]
+	bagClient      http.Client[bagResult]
 	httpClient     http.Client[interface{}]
 	machine        machine.Machine
 	os             operatingsystem.OperatingSystem
@@ -60,6 +63,7 @@ func NewAppStore(args Args) AppStore {
 		searchClient:   http.NewClient[searchResult](clientArgs),
 		purchaseClient: http.NewClient[purchaseResult](clientArgs),
 		downloadClient: http.NewClient[downloadResult](clientArgs),
+		bagClient:      http.NewClient[bagResult](clientArgs),
 		httpClient:     http.NewClient[interface{}](clientArgs),
 		machine:        args.Machine,
 		os:             args.OperatingSystem,

--- a/pkg/appstore/appstore_bag.go
+++ b/pkg/appstore/appstore_bag.go
@@ -1,0 +1,57 @@
+package appstore
+
+import (
+	"fmt"
+	gohttp "net/http"
+	"strings"
+
+	"github.com/majd/ipatool/v2/pkg/http"
+)
+
+type BagInput struct{}
+
+type BagOutput struct {
+	AuthEndpoint string
+}
+
+func (t *appstore) Bag(input BagInput) (BagOutput, error) {
+	macAddr, err := t.machine.MacAddress()
+	if err != nil {
+		return BagOutput{}, fmt.Errorf("failed to get mac address: %w", err)
+	}
+
+	guid := strings.ReplaceAll(strings.ToUpper(macAddr), ":", "")
+	req := t.bagRequest(guid)
+
+	res, err := t.bagClient.Send(req)
+	if err != nil {
+		return BagOutput{}, fmt.Errorf("failed to send http request: %w", err)
+	}
+
+	if res.StatusCode != gohttp.StatusOK {
+		return BagOutput{}, fmt.Errorf("received unexpected status code: %d", res.StatusCode)
+	}
+
+	return BagOutput{
+		AuthEndpoint: res.Data.URLBag.AuthEndpoint,
+	}, nil
+}
+
+type bagResult struct {
+	URLBag urlBag `plist:"urlBag,omitempty"`
+}
+
+type urlBag struct {
+	AuthEndpoint string `plist:"authenticateAccount,omitempty"`
+}
+
+func (*appstore) bagRequest(guid string) http.Request {
+	return http.Request{
+		URL:            fmt.Sprintf("https://%s%s?guid=%s", PrivateInitDomain, PrivateInitPath, guid),
+		Method:         http.MethodGET,
+		ResponseFormat: http.ResponseFormatXML,
+		Headers: map[string]string{
+			"Accept": "application/xml",
+		},
+	}
+}

--- a/pkg/appstore/appstore_bag_test.go
+++ b/pkg/appstore/appstore_bag_test.go
@@ -1,0 +1,120 @@
+package appstore
+
+import (
+	"errors"
+	gohttp "net/http"
+
+	"github.com/majd/ipatool/v2/pkg/http"
+	"github.com/majd/ipatool/v2/pkg/util/machine"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+)
+
+var _ = Describe("AppStore (Bag)", func() {
+	var (
+		ctrl          *gomock.Controller
+		mockBagClient *http.MockClient[bagResult]
+		mockMachine   *machine.MockMachine
+		as            AppStore
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockBagClient = http.NewMockClient[bagResult](ctrl)
+		mockMachine = machine.NewMockMachine(ctrl)
+		as = &appstore{
+			bagClient: mockBagClient,
+			machine:   mockMachine,
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	When("fails to read machine MAC address", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("", errors.New("mac error"))
+		})
+
+		It("returns error", func() {
+			_, err := as.Bag(BagInput{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get mac address"))
+		})
+	})
+
+	When("request fails", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			mockBagClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[bagResult]{}, errors.New("request error"))
+		})
+
+		It("returns wrapped error", func() {
+			_, err := as.Bag(BagInput{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to send http request"))
+		})
+	})
+
+	When("request returns non-200 status code", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			mockBagClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[bagResult]{
+					StatusCode: gohttp.StatusForbidden,
+				}, nil)
+		})
+
+		It("returns error", func() {
+			_, err := as.Bag(BagInput{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("received unexpected status code"))
+		})
+	})
+
+	When("request is successful", func() {
+		const testAuthEndpoint = "https://example.com"
+
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("aa:bb:cc:dd:ee:ff", nil)
+
+			mockBagClient.EXPECT().
+				Send(gomock.Any()).
+				Do(func(req http.Request) {
+					Expect(req.Method).To(Equal(http.MethodGET))
+					Expect(req.URL).To(Equal("https://init.itunes.apple.com/bag.xml?guid=AABBCCDDEEFF"))
+					Expect(req.ResponseFormat).To(Equal(http.ResponseFormatXML))
+					Expect(req.Headers).To(HaveKeyWithValue("Accept", "application/xml"))
+				}).
+				Return(http.Result[bagResult]{
+					StatusCode: gohttp.StatusOK,
+					Data: bagResult{
+						URLBag: urlBag{
+							AuthEndpoint: testAuthEndpoint,
+						},
+					},
+				}, nil)
+		})
+
+		It("returns output", func() {
+			out, err := as.Bag(BagInput{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.AuthEndpoint).To(Equal(testAuthEndpoint))
+		})
+	})
+})

--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -168,8 +168,6 @@ func (t *appstore) downloadFile(src, dst string, progress *progressbar.ProgressB
 }
 
 func (*appstore) downloadRequest(acc Account, app App, guid string, externalVersionID string) http.Request {
-	host := fmt.Sprintf("%s-%s", PrivateAppStoreAPIDomainPrefixWithoutAuthCode, PrivateAppStoreAPIDomain)
-
 	payload := map[string]interface{}{
 		"creditDisplay": "",
 		"guid":          guid,
@@ -180,8 +178,13 @@ func (*appstore) downloadRequest(acc Account, app App, guid string, externalVers
 		payload["externalVersionId"] = externalVersionID
 	}
 
+	podPrefix := ""
+	if acc.Pod != "" {
+		podPrefix = "p" + acc.Pod + "-"
+	}
+
 	return http.Request{
-		URL:            fmt.Sprintf("https://%s%s?guid=%s", host, PrivateAppStoreAPIPathDownload, guid),
+		URL:            fmt.Sprintf("https://%s%s%s?guid=%s", podPrefix, PrivateAppStoreAPIDomain, PrivateAppStoreAPIPathDownload, guid),
 		Method:         http.MethodPOST,
 		ResponseFormat: http.ResponseFormatXML,
 		Headers: map[string]string{

--- a/pkg/appstore/appstore_download_test.go
+++ b/pkg/appstore/appstore_download_test.go
@@ -97,6 +97,36 @@ var _ = Describe("AppStore (Download)", func() {
 		})
 	})
 
+	When("request uses a custom pod", func() {
+		const (
+			testPod  = "42"
+			testGUID = "001122334455"
+		)
+
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			mockDownloadClient.EXPECT().
+				Send(gomock.Any()).
+				Do(func(req http.Request) {
+					expectedURL := "https://p" + testPod + "-" + PrivateAppStoreAPIDomain + PrivateAppStoreAPIPathDownload + "?guid=" + testGUID
+					Expect(req.URL).To(Equal(expectedURL))
+				}).
+				Return(http.Result[downloadResult]{}, errors.New(""))
+		})
+
+		It("sends the download request to the pod-specific host", func() {
+			_, err := as.Download(DownloadInput{
+				Account: Account{
+					Pod: testPod,
+				},
+			})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	When("password token is expired", func() {
 		BeforeEach(func() {
 			mockMachine.EXPECT().

--- a/pkg/appstore/appstore_get_version_metadata.go
+++ b/pkg/appstore/appstore_get_version_metadata.go
@@ -69,8 +69,6 @@ func (t *appstore) GetVersionMetadata(input GetVersionMetadataInput) (GetVersion
 }
 
 func (t *appstore) getVersionMetadataRequest(acc Account, app App, guid string, version string) http.Request {
-	host := fmt.Sprintf("%s-%s", PrivateAppStoreAPIDomainPrefixWithoutAuthCode, PrivateAppStoreAPIDomain)
-
 	payload := map[string]interface{}{
 		"creditDisplay":     "",
 		"guid":              guid,
@@ -78,8 +76,13 @@ func (t *appstore) getVersionMetadataRequest(acc Account, app App, guid string, 
 		"externalVersionId": version,
 	}
 
+	podPrefix := ""
+	if acc.Pod != "" {
+		podPrefix = "p" + acc.Pod + "-"
+	}
+
 	return http.Request{
-		URL:            fmt.Sprintf("https://%s%s?guid=%s", host, PrivateAppStoreAPIPathDownload, guid),
+		URL:            fmt.Sprintf("https://%s%s%s?guid=%s", podPrefix, PrivateAppStoreAPIDomain, PrivateAppStoreAPIPathDownload, guid),
 		Method:         http.MethodPOST,
 		ResponseFormat: http.ResponseFormatXML,
 		Headers: map[string]string{

--- a/pkg/appstore/appstore_list_versions.go
+++ b/pkg/appstore/appstore_list_versions.go
@@ -77,16 +77,19 @@ func (t *appstore) ListVersions(input ListVersionsInput) (ListVersionsOutput, er
 }
 
 func (t *appstore) listVersionsRequest(acc Account, app App, guid string) http.Request {
-	host := fmt.Sprintf("%s-%s", PrivateAppStoreAPIDomainPrefixWithoutAuthCode, PrivateAppStoreAPIDomain)
-
 	payload := map[string]interface{}{
 		"creditDisplay": "",
 		"guid":          guid,
 		"salableAdamId": app.ID,
 	}
 
+	podPrefix := ""
+	if acc.Pod != "" {
+		podPrefix = "p" + acc.Pod + "-"
+	}
+
 	return http.Request{
-		URL:            fmt.Sprintf("https://%s%s?guid=%s", host, PrivateAppStoreAPIPathDownload, guid),
+		URL:            fmt.Sprintf("https://%s%s%s?guid=%s", podPrefix, PrivateAppStoreAPIDomain, PrivateAppStoreAPIPathDownload, guid),
 		Method:         http.MethodPOST,
 		ResponseFormat: http.ResponseFormatXML,
 		Headers: map[string]string{

--- a/pkg/appstore/appstore_list_versions_test.go
+++ b/pkg/appstore/appstore_list_versions_test.go
@@ -62,6 +62,36 @@ var _ = Describe("AppStore (ListVersions)", func() {
 		})
 	})
 
+	When("request uses a custom pod", func() {
+		const (
+			testPod  = "42"
+			testGUID = "001122334455"
+		)
+
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			mockDownloadClient.EXPECT().
+				Send(gomock.Any()).
+				Do(func(req http.Request) {
+					expectedURL := "https://p" + testPod + "-" + PrivateAppStoreAPIDomain + PrivateAppStoreAPIPathDownload + "?guid=" + testGUID
+					Expect(req.URL).To(Equal(expectedURL))
+				}).
+				Return(http.Result[downloadResult]{}, errors.New(""))
+		})
+
+		It("sends the request to the pod-specific host", func() {
+			_, err := as.ListVersions(ListVersionsInput{
+				Account: Account{
+					Pod: testPod,
+				},
+			})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	When("password token is expired", func() {
 		BeforeEach(func() {
 			mockMachine.EXPECT().

--- a/pkg/appstore/appstore_login_test.go
+++ b/pkg/appstore/appstore_login_test.go
@@ -20,6 +20,7 @@ var _ = Describe("AppStore (Login)", func() {
 		testEmail     = "test-email"
 		testFirstName = "test-first-name"
 		testLastName  = "test-last-name"
+		testPod       = "42"
 	)
 
 	var (
@@ -165,7 +166,7 @@ var _ = Describe("AppStore (Login)", func() {
 
 		When("store API redirects", func() {
 			const (
-				testRedirectLocation = "https://" + PrivateAppStoreAPIDomain + PrivateAppStoreAPIPathAuthenticate + "?PRH=31&Pod=31"
+				testRedirectLocation = "https://test-redirect-url.com"
 			)
 
 			BeforeEach(func() {
@@ -230,7 +231,10 @@ var _ = Describe("AppStore (Login)", func() {
 					Send(gomock.Any()).
 					Return(http.Result[loginResult]{
 						StatusCode: 200,
-						Headers:    map[string]string{HTTPHeaderStoreFront: testStoreFront},
+						Headers: map[string]string{
+							HTTPHeaderStoreFront: testStoreFront,
+							HTTPHeaderPod:        testPod,
+						},
 						Data: loginResult{
 							PasswordToken:       testPasswordToken,
 							DirectoryServicesID: testDirectoryServicesID,
@@ -257,6 +261,7 @@ var _ = Describe("AppStore (Login)", func() {
 								Password:            testPassword,
 								DirectoryServicesID: testDirectoryServicesID,
 								StoreFront:          testStoreFront,
+								Pod:                 testPod,
 							}
 
 							var got Account
@@ -287,6 +292,7 @@ var _ = Describe("AppStore (Login)", func() {
 								Password:            testPassword,
 								DirectoryServicesID: testDirectoryServicesID,
 								StoreFront:          testStoreFront,
+								Pod:                 testPod,
 							}
 
 							var got Account

--- a/pkg/appstore/appstore_purchase.go
+++ b/pkg/appstore/appstore_purchase.go
@@ -96,8 +96,13 @@ func (t *appstore) purchaseWithParams(acc Account, app App, guid string, pricing
 }
 
 func (t *appstore) purchaseRequest(acc Account, app App, storeFront, guid string, pricingParameters string) http.Request {
+	podPrefix := ""
+	if acc.Pod != "" {
+		podPrefix = "p" + acc.Pod + "-"
+	}
+
 	return http.Request{
-		URL:            fmt.Sprintf("https://%s%s", PrivateAppStoreAPIDomain, PrivateAppStoreAPIPathPurchase),
+		URL:            fmt.Sprintf("https://%s%s%s", podPrefix, PrivateAppStoreAPIDomain, PrivateAppStoreAPIPathPurchase),
 		Method:         http.MethodPOST,
 		ResponseFormat: http.ResponseFormatXML,
 		Headers: map[string]string{

--- a/pkg/appstore/constants.go
+++ b/pkg/appstore/constants.go
@@ -14,6 +14,9 @@ const (
 	iTunesAPIPathSearch = "/search"
 	iTunesAPIPathLookup = "/lookup"
 
+	PrivateInitDomain = "init." + iTunesAPIDomain
+	PrivateInitPath   = "/bag.xml"
+
 	PrivateAppStoreAPIDomainPrefixWithoutAuthCode = "p25"
 	PrivateAppStoreAPIDomainPrefixWithAuthCode    = "p71"
 	PrivateAppStoreAPIDomain                      = "buy." + iTunesAPIDomain

--- a/pkg/appstore/constants.go
+++ b/pkg/appstore/constants.go
@@ -20,11 +20,11 @@ const (
 	PrivateAppStoreAPIDomainPrefixWithoutAuthCode = "p25"
 	PrivateAppStoreAPIDomainPrefixWithAuthCode    = "p71"
 	PrivateAppStoreAPIDomain                      = "buy." + iTunesAPIDomain
-	PrivateAppStoreAPIPathAuthenticate            = "/WebObjects/MZFinance.woa/wa/authenticate"
 	PrivateAppStoreAPIPathPurchase                = "/WebObjects/MZFinance.woa/wa/buyProduct"
 	PrivateAppStoreAPIPathDownload                = "/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct"
 
 	HTTPHeaderStoreFront = "X-Set-Apple-Store-Front"
+	HTTPHeaderPod        = "pod"
 
 	PricingParameterAppStore    = "STDQ"
 	PricingParameterAppleArcade = "GAME"

--- a/pkg/appstore/constants.go
+++ b/pkg/appstore/constants.go
@@ -17,11 +17,9 @@ const (
 	PrivateInitDomain = "init." + iTunesAPIDomain
 	PrivateInitPath   = "/bag.xml"
 
-	PrivateAppStoreAPIDomainPrefixWithoutAuthCode = "p25"
-	PrivateAppStoreAPIDomainPrefixWithAuthCode    = "p71"
-	PrivateAppStoreAPIDomain                      = "buy." + iTunesAPIDomain
-	PrivateAppStoreAPIPathPurchase                = "/WebObjects/MZFinance.woa/wa/buyProduct"
-	PrivateAppStoreAPIPathDownload                = "/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct"
+	PrivateAppStoreAPIDomain       = "buy." + iTunesAPIDomain
+	PrivateAppStoreAPIPathPurchase = "/WebObjects/MZFinance.woa/wa/buyProduct"
+	PrivateAppStoreAPIPathDownload = "/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct"
 
 	HTTPHeaderStoreFront = "X-Set-Apple-Store-Front"
 	HTTPHeaderPod        = "pod"

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"howett.net/plist"
@@ -13,6 +14,12 @@ import (
 
 const (
 	appStoreAuthURL = "https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/authenticate"
+)
+
+var (
+	documentXMLPattern = regexp.MustCompile(`(?is)<Document\b[^>]*>(.*)</Document>`)
+	plistXMLPattern    = regexp.MustCompile(`(?is)<plist\b[^>]*>.*?</plist>`)
+	dictXMLPattern     = regexp.MustCompile(`(?is)<dict\b[^>]*>.*</dict>`)
 )
 
 //go:generate go run go.uber.org/mock/mockgen -source=client.go -destination=client_mock.go -package=http
@@ -155,7 +162,9 @@ func (c *client[R]) handleXMLResponse(res *http.Response) (Result[R], error) {
 
 	var data R
 
-	_, err = plist.Unmarshal(body, &data)
+	normalizedBody := normalizeXMLPlistBody(body)
+
+	_, err = plist.Unmarshal(normalizedBody, &data)
 	if err != nil {
 		return Result[R]{}, fmt.Errorf("failed to unmarshal xml: %w", err)
 	}
@@ -170,4 +179,61 @@ func (c *client[R]) handleXMLResponse(res *http.Response) (Result[R], error) {
 		Headers:    headers,
 		Data:       data,
 	}, nil
+}
+
+func normalizeXMLPlistBody(body []byte) []byte {
+	normalized := bytes.TrimSpace(body)
+	if len(normalized) == 0 {
+		return normalized
+	}
+
+	if documentBody := extractDocumentInnerBody(normalized); len(documentBody) > 0 {
+		normalized = documentBody
+	}
+
+	if embeddedPlist := extractEmbeddedPlist(normalized); len(embeddedPlist) > 0 {
+		normalized = embeddedPlist
+	}
+
+	if dictBody := extractEmbeddedDict(normalized); len(dictBody) > 0 {
+		return dictBody
+	}
+
+	if bytes.Contains(normalized, []byte("<key>")) {
+		return []byte("<dict>" + string(normalized) + "</dict>")
+	}
+
+	return normalized
+}
+
+func extractEmbeddedPlist(body []byte) []byte {
+	plistMatch := plistXMLPattern.Find(body)
+	if len(plistMatch) == 0 {
+		return nil
+	}
+
+	return bytes.TrimSpace(plistMatch)
+}
+
+func extractEmbeddedDict(body []byte) []byte {
+	dictMatch := dictXMLPattern.Find(body)
+	if len(dictMatch) == 0 {
+		return nil
+	}
+
+	return bytes.TrimSpace(dictMatch)
+}
+
+func extractDocumentInnerBody(body []byte) []byte {
+	documentMatch := documentXMLPattern.FindSubmatch(body)
+	if len(documentMatch) < 2 {
+		return nil
+	}
+
+	documentBody := bytes.TrimSpace(documentMatch[1])
+	if len(documentBody) == 0 {
+		return nil
+	}
+
+	return documentBody
 }


### PR DESCRIPTION
This pull request introduces support for "pod"-specific App Store endpoints, enhancing how requests are routed and authenticated. The main changes involve fetching the correct authentication endpoint dynamically, propagating the "pod" information through the login flow, and updating all relevant requests to use the pod-specific host if available. Comprehensive tests have been added for these new behaviors.

**Pod-aware endpoint support:**

- Added a new `Bag` method to the `AppStore` interface and its implementation, which fetches endpoint definitions (including the authentication endpoint) from the App Store "bag" service. (`pkg/appstore/appstore.go`, `pkg/appstore/appstore_bag.go`, [[1]](diffhunk://#diff-d64a9d58c378389f761be701891bf01ac3fb4da658647668b639b6263ee45e3aR32-R33) [[2]](diffhunk://#diff-4807dd188b9f8e6a0da96fae2751c2aa4a4ad86b6de6b8c5bf49a4187047febdR1-R57)
- Updated the login flow to use the authentication endpoint from the bag and to extract and store the "pod" value from login responses in the `Account` struct. (`cmd/auth.go`, `pkg/appstore/account.go`, `pkg/appstore/appstore_login.go`, [[1]](diffhunk://#diff-2a99768a3ac5c528aaefcdbcfc65b406d9913e150e08dab88cfbeacdd19793a8R86-R95) [[2]](diffhunk://#diff-141e206a132d5bb171778c0cc682d72ea742ac30859d69ef4dfbe5562e1d3b52R10) [[3]](diffhunk://#diff-c9c02021e9c9ea0b2e9dcc21cd5223a5c6ff6f9d8207d56f59dbb8a01f95216fR23) [[4]](diffhunk://#diff-c9c02021e9c9ea0b2e9dcc21cd5223a5c6ff6f9d8207d56f59dbb8a01f95216fL37-R38) [[5]](diffhunk://#diff-c9c02021e9c9ea0b2e9dcc21cd5223a5c6ff6f9d8207d56f59dbb8a01f95216fL65-R66) [[6]](diffhunk://#diff-c9c02021e9c9ea0b2e9dcc21cd5223a5c6ff6f9d8207d56f59dbb8a01f95216fL76-R77) [[7]](diffhunk://#diff-c9c02021e9c9ea0b2e9dcc21cd5223a5c6ff6f9d8207d56f59dbb8a01f95216fR99-R103) [[8]](diffhunk://#diff-c9c02021e9c9ea0b2e9dcc21cd5223a5c6ff6f9d8207d56f59dbb8a01f95216fR112) [[9]](diffhunk://#diff-c9c02021e9c9ea0b2e9dcc21cd5223a5c6ff6f9d8207d56f59dbb8a01f95216fL153-R163)

**Pod-specific request routing:**

- Modified download, version metadata, and list versions requests to use a pod-specific host if the `Account.Pod` field is set, ensuring requests are routed correctly for users assigned to a particular pod. (`pkg/appstore/appstore_download.go`, `pkg/appstore/appstore_get_version_metadata.go`, `pkg/appstore/appstore_list_versions.go`, [[1]](diffhunk://#diff-3fa972242b4d64beec128d2a595daa77b7feb085ca4f8dd000e038b9a1661443L151-L152) [[2]](diffhunk://#diff-3fa972242b4d64beec128d2a595daa77b7feb085ca4f8dd000e038b9a1661443R161-R167) [[3]](diffhunk://#diff-7eb167ca2b8359b153deb8c02e5fea152333ef8b9aac5089bab2286dfd3877b6L72-R85) [[4]](diffhunk://#diff-9ed863ad64529b95c50ad21d6873079bc98718d35348880c51ae3a54db67ba08L80-R92)

**Testing improvements:**

- Added new tests for the `Bag` method, as well as tests to verify that pod-specific hosts are used in download, get version metadata, and list versions requests. (`pkg/appstore/appstore_bag_test.go`, `pkg/appstore/appstore_download_test.go`, `pkg/appstore/appstore_get_version_metadata_test.go`, `pkg/appstore/appstore_list_versions_test.go`, [[1]](diffhunk://#diff-57ad2af75b15486d22b374036f403b2e84019cead242b75374097ea9b2d76147R1-R120) [[2]](diffhunk://#diff-417c21c44c6e0e1f0cfc1d7e64afc1f5f53db0be0437a3b6348fa5008e66ee44R89-R118) [[3]](diffhunk://#diff-4a4f934d82b179de20cfe1997d15de493163a82afd9fd2f626b65cb23a3a0da7R68-R98) [[4]](diffhunk://#diff-401e91622e1b2899ab79e66e8026dafa79fc44df3a6f5e5aca5719096fe6a132R65-R94)
- Enhanced login tests to check for correct handling of the "pod" value in the `Account` struct and in request routing. (`pkg/appstore/appstore_login_test.go`, [[1]](diffhunk://#diff-85ec7ce059b839953a1e9938c7a7a455cd589415169816d79b205c58a854022fR23) [[2]](diffhunk://#diff-85ec7ce059b839953a1e9938c7a7a455cd589415169816d79b205c58a854022fL168-R169) [[3]](diffhunk://#diff-85ec7ce059b839953a1e9938c7a7a455cd589415169816d79b205c58a854022fL233-R237) [[4]](diffhunk://#diff-85ec7ce059b839953a1e9938c7a7a455cd589415169816d79b205c58a854022fR264) [[5]](diffhunk://#diff-85ec7ce059b839953a1e9938c7a7a455cd589415169816d79b205c58a854022fR295)