### PR TITLE
Fix re-authentication in retry logic by resolving auth endpoint via Bag()

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"time"
 
@@ -42,7 +43,16 @@ func downloadCmd() *cobra.Command {
 				acc = infoResult.Account
 
 				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
-					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{Email: acc.Email, Password: acc.Password})
+					bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
+					if err != nil {
+						return fmt.Errorf("failed to get bag: %w", err)
+					}
+
+					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{
+						Email:    acc.Email,
+						Password: acc.Password,
+						Endpoint: bagOutput.AuthEndpoint,
+					})
 					if err != nil {
 						return err
 					}
@@ -112,7 +122,7 @@ func downloadCmd() *cobra.Command {
 				retry.LastErrorOnly(true),
 				retry.DelayType(retry.FixedDelay),
 				retry.Delay(time.Millisecond),
-				retry.Attempts(2),
+				retry.Attempts(3),
 				retry.RetryIf(func(err error) bool {
 					lastErr = err
 

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -72,7 +72,7 @@ func downloadCmd() *cobra.Command {
 
 				if errors.Is(lastErr, appstore.ErrLicenseRequired) {
 					err := dependencies.AppStore.Purchase(appstore.PurchaseInput{Account: acc, App: app})
-					if err != nil {
+					if err != nil && !errors.Is(err, appstore.ErrLicenseAlreadyExists) {
 						return err
 					}
 					purchased = true

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"time"
 
@@ -43,15 +42,10 @@ func downloadCmd() *cobra.Command {
 				acc = infoResult.Account
 
 				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
-					bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
-					if err != nil {
-						return fmt.Errorf("failed to get bag: %w", err)
-					}
-
 					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{
 						Email:    acc.Email,
 						Password: acc.Password,
-						Endpoint: bagOutput.AuthEndpoint,
+						Endpoint: appstore.DefaultAuthEndpoint,
 					})
 					if err != nil {
 						return err

--- a/cmd/get_version_metadata.go
+++ b/cmd/get_version_metadata.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -37,7 +38,16 @@ func getVersionMetadataCmd() *cobra.Command {
 				acc = infoResult.Account
 
 				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
-					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{Email: acc.Email, Password: acc.Password})
+					bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
+					if err != nil {
+						return fmt.Errorf("failed to get bag: %w", err)
+					}
+
+					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{
+						Email:    acc.Email,
+						Password: acc.Password,
+						Endpoint: bagOutput.AuthEndpoint,
+					})
 					if err != nil {
 						return err
 					}

--- a/cmd/get_version_metadata.go
+++ b/cmd/get_version_metadata.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -38,15 +37,10 @@ func getVersionMetadataCmd() *cobra.Command {
 				acc = infoResult.Account
 
 				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
-					bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
-					if err != nil {
-						return fmt.Errorf("failed to get bag: %w", err)
-					}
-
 					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{
 						Email:    acc.Email,
 						Password: acc.Password,
-						Endpoint: bagOutput.AuthEndpoint,
+						Endpoint: appstore.DefaultAuthEndpoint,
 					})
 					if err != nil {
 						return err

--- a/cmd/list_versions.go
+++ b/cmd/list_versions.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -37,15 +36,10 @@ func ListVersionsCmd() *cobra.Command {
 				acc = infoResult.Account
 
 				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
-					bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
-					if err != nil {
-						return fmt.Errorf("failed to get bag: %w", err)
-					}
-
 					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{
 						Email:    acc.Email,
 						Password: acc.Password,
-						Endpoint: bagOutput.AuthEndpoint,
+						Endpoint: appstore.DefaultAuthEndpoint,
 					})
 					if err != nil {
 						return err

--- a/cmd/list_versions.go
+++ b/cmd/list_versions.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -36,7 +37,16 @@ func ListVersionsCmd() *cobra.Command {
 				acc = infoResult.Account
 
 				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
-					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{Email: acc.Email, Password: acc.Password})
+					bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
+					if err != nil {
+						return fmt.Errorf("failed to get bag: %w", err)
+					}
+
+					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{
+						Email:    acc.Email,
+						Password: acc.Password,
+						Endpoint: bagOutput.AuthEndpoint,
+					})
 					if err != nil {
 						return err
 					}

--- a/cmd/purchase.go
+++ b/cmd/purchase.go
@@ -53,11 +53,14 @@ func purchaseCmd() *cobra.Command {
 				}
 
 				err = dependencies.AppStore.Purchase(appstore.PurchaseInput{Account: acc, App: lookupResult.App})
-				if err != nil {
+				if err != nil && !errors.Is(err, appstore.ErrLicenseAlreadyExists) {
 					return err
 				}
 
-				dependencies.Logger.Log().Bool("success", true).Send()
+				dependencies.Logger.Log().
+					Bool("alreadyOwned", errors.Is(err, appstore.ErrLicenseAlreadyExists)).
+					Bool("success", true).
+					Send()
 
 				return nil
 			},

--- a/cmd/purchase.go
+++ b/cmd/purchase.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -30,15 +29,10 @@ func purchaseCmd() *cobra.Command {
 				acc = infoResult.Account
 
 				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
-					bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
-					if err != nil {
-						return fmt.Errorf("failed to get bag: %w", err)
-					}
-
 					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{
 						Email:    acc.Email,
 						Password: acc.Password,
-						Endpoint: bagOutput.AuthEndpoint,
+						Endpoint: appstore.DefaultAuthEndpoint,
 					})
 					if err != nil {
 						return err

--- a/cmd/purchase.go
+++ b/cmd/purchase.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -29,7 +30,16 @@ func purchaseCmd() *cobra.Command {
 				acc = infoResult.Account
 
 				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
-					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{Email: acc.Email, Password: acc.Password})
+					bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
+					if err != nil {
+						return fmt.Errorf("failed to get bag: %w", err)
+					}
+
+					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{
+						Email:    acc.Email,
+						Password: acc.Password,
+						Endpoint: bagOutput.AuthEndpoint,
+					})
 					if err != nil {
 						return err
 					}

--- a/pkg/appstore/appstore_bag.go
+++ b/pkg/appstore/appstore_bag.go
@@ -32,13 +32,8 @@ func (t *appstore) Bag(input BagInput) (BagOutput, error) {
 		return BagOutput{}, fmt.Errorf("received unexpected status code: %d", res.StatusCode)
 	}
 
-	authEndpoint := res.Data.URLBag.AuthEndpoint
-	if authEndpoint == "" {
-		authEndpoint = fmt.Sprintf("https://%s%s", PrivateAppStoreAPIDomain, PrivateAppStoreAPIPathAuthenticate)
-	}
-
 	return BagOutput{
-		AuthEndpoint: authEndpoint,
+		AuthEndpoint: res.Data.URLBag.AuthEndpoint,
 	}, nil
 }
 

--- a/pkg/appstore/appstore_bag.go
+++ b/pkg/appstore/appstore_bag.go
@@ -34,7 +34,7 @@ func (t *appstore) Bag(input BagInput) (BagOutput, error) {
 
 	authEndpoint := res.Data.URLBag.AuthEndpoint
 	if authEndpoint == "" {
-		authEndpoint = PrivateAppStoreAPIPathAuthenticate
+		authEndpoint = fmt.Sprintf("https://%s%s", PrivateAppStoreAPIDomain, PrivateAppStoreAPIPathAuthenticate)
 	}
 
 	return BagOutput{

--- a/pkg/appstore/appstore_bag.go
+++ b/pkg/appstore/appstore_bag.go
@@ -32,8 +32,13 @@ func (t *appstore) Bag(input BagInput) (BagOutput, error) {
 		return BagOutput{}, fmt.Errorf("received unexpected status code: %d", res.StatusCode)
 	}
 
+	authEndpoint := res.Data.URLBag.AuthEndpoint
+	if authEndpoint == "" {
+		authEndpoint = PrivateAppStoreAPIPathAuthenticate
+	}
+
 	return BagOutput{
-		AuthEndpoint: res.Data.URLBag.AuthEndpoint,
+		AuthEndpoint: authEndpoint,
 	}, nil
 }
 

--- a/pkg/appstore/appstore_bag_test.go
+++ b/pkg/appstore/appstore_bag_test.go
@@ -135,7 +135,7 @@ var _ = Describe("AppStore (Bag)", func() {
 		It("falls back to hardcoded auth endpoint", func() {
 			out, err := as.Bag(BagInput{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(out.AuthEndpoint).To(Equal(PrivateAppStoreAPIPathAuthenticate))
+			Expect(out.AuthEndpoint).To(Equal("https://" + PrivateAppStoreAPIDomain + PrivateAppStoreAPIPathAuthenticate))
 		})
 	})
 })

--- a/pkg/appstore/appstore_bag_test.go
+++ b/pkg/appstore/appstore_bag_test.go
@@ -85,7 +85,7 @@ var _ = Describe("AppStore (Bag)", func() {
 		})
 	})
 
-	When("request is successful", func() {
+	When("request is successful with authenticateAccount in urlBag", func() {
 		const testAuthEndpoint = "https://example.com"
 
 		BeforeEach(func() {
@@ -115,6 +115,27 @@ var _ = Describe("AppStore (Bag)", func() {
 			out, err := as.Bag(BagInput{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out.AuthEndpoint).To(Equal(testAuthEndpoint))
+		})
+	})
+
+	When("request is successful but authenticateAccount is empty", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("aa:bb:cc:dd:ee:ff", nil)
+
+			mockBagClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[bagResult]{
+					StatusCode: gohttp.StatusOK,
+					Data:       bagResult{},
+				}, nil)
+		})
+
+		It("falls back to hardcoded auth endpoint", func() {
+			out, err := as.Bag(BagInput{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.AuthEndpoint).To(Equal(PrivateAppStoreAPIPathAuthenticate))
 		})
 	})
 })

--- a/pkg/appstore/appstore_bag_test.go
+++ b/pkg/appstore/appstore_bag_test.go
@@ -132,10 +132,10 @@ var _ = Describe("AppStore (Bag)", func() {
 				}, nil)
 		})
 
-		It("falls back to hardcoded auth endpoint", func() {
+		It("returns empty auth endpoint", func() {
 			out, err := as.Bag(BagInput{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(out.AuthEndpoint).To(Equal("https://" + PrivateAppStoreAPIDomain + PrivateAppStoreAPIPathAuthenticate))
+			Expect(out.AuthEndpoint).To(BeEmpty())
 		})
 	})
 })

--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -46,7 +46,9 @@ func (t *appstore) Download(input DownloadInput) (DownloadOutput, error) {
 		return DownloadOutput{}, fmt.Errorf("failed to send http request: %w", err)
 	}
 
-	if res.Data.FailureType == FailureTypePasswordTokenExpired {
+	if res.Data.FailureType == FailureTypePasswordTokenExpired ||
+		res.Data.FailureType == FailureTypeDeviceVerificationFailed ||
+		res.Data.FailureType == FailureTypeLicenseAlreadyExists {
 		return DownloadOutput{}, ErrPasswordTokenExpired
 	}
 

--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -82,12 +82,13 @@ func (t *appstore) Download(input DownloadInput) (DownloadOutput, error) {
 		return DownloadOutput{}, fmt.Errorf("failed to resolve destination path: %w", err)
 	}
 
-	err = t.downloadFile(item.URL, fmt.Sprintf("%s.tmp", destination), input.Progress)
+	tmpPath := fmt.Sprintf("%s.tmp", destination)
+	err = t.downloadFile(item.URL, tmpPath, input.Progress)
 	if err != nil {
 		return DownloadOutput{}, fmt.Errorf("failed to download file: %w", err)
 	}
 
-	err = t.applyPatches(item, input.Account, fmt.Sprintf("%s.tmp", destination), destination)
+	err = t.applyPatches(item, input.Account, tmpPath, destination)
 	if err != nil {
 		return DownloadOutput{}, fmt.Errorf("failed to apply patches: %w", err)
 	}
@@ -262,10 +263,11 @@ func (t *appstore) applyPatches(item downloadItemResult, acc Account, src, dst s
 	}
 	defer srcZip.Close()
 
-	dstFile, err := t.os.OpenFile(dst, os.O_CREATE|os.O_WRONLY, 0644)
+	dstFile, err := t.os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open file: %w", err)
 	}
+	defer dstFile.Close()
 
 	dstZip := zip.NewWriter(dstFile)
 	defer dstZip.Close()

--- a/pkg/appstore/appstore_purchase.go
+++ b/pkg/appstore/appstore_purchase.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	ErrPasswordTokenExpired   = errors.New("password token is expired")
+	ErrLicenseAlreadyExists   = errors.New("license already exists")
 	ErrSubscriptionRequired   = errors.New("subscription required")
 	ErrTemporarilyUnavailable = errors.New("item is temporarily unavailable")
 )
@@ -72,8 +73,14 @@ func (t *appstore) purchaseWithParams(acc Account, app App, guid string, pricing
 		return ErrSubscriptionRequired
 	}
 
-	if res.Data.FailureType == FailureTypePasswordTokenExpired || res.Data.CustomerMessage == CustomerMessagePasswordChanged {
+	if res.Data.FailureType == FailureTypePasswordTokenExpired ||
+		res.Data.FailureType == FailureTypeDeviceVerificationFailed ||
+		res.Data.CustomerMessage == CustomerMessagePasswordChanged {
 		return ErrPasswordTokenExpired
+	}
+
+	if res.Data.FailureType == FailureTypeLicenseAlreadyExists {
+		return ErrLicenseAlreadyExists
 	}
 
 	if res.Data.FailureType != "" && res.Data.CustomerMessage != "" {
@@ -85,7 +92,7 @@ func (t *appstore) purchaseWithParams(acc Account, app App, guid string, pricing
 	}
 
 	if res.StatusCode == gohttp.StatusInternalServerError {
-		return fmt.Errorf("license already exists")
+		return ErrLicenseAlreadyExists
 	}
 
 	if res.Data.JingleDocType != "purchaseSuccess" || res.Data.Status != 0 {

--- a/pkg/appstore/appstore_purchase.go
+++ b/pkg/appstore/appstore_purchase.go
@@ -72,7 +72,7 @@ func (t *appstore) purchaseWithParams(acc Account, app App, guid string, pricing
 		return ErrSubscriptionRequired
 	}
 
-	if res.Data.FailureType == FailureTypePasswordTokenExpired {
+	if res.Data.FailureType == FailureTypePasswordTokenExpired || res.Data.CustomerMessage == CustomerMessagePasswordChanged {
 		return ErrPasswordTokenExpired
 	}
 

--- a/pkg/appstore/appstore_purchase_test.go
+++ b/pkg/appstore/appstore_purchase_test.go
@@ -229,7 +229,34 @@ var _ = Describe("AppStore (Purchase)", func() {
 		})
 	})
 
-	When("account already has a license for the app", func() {
+	When("account already has a license for the app (failure type)", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:00:00:00:00:00", nil)
+
+			mockPurchaseClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[purchaseResult]{
+					StatusCode: 200,
+					Data: purchaseResult{
+						FailureType:     FailureTypeLicenseAlreadyExists,
+						CustomerMessage: "An unknown error has occurred",
+					},
+				}, nil)
+		})
+
+		It("returns license already exists error", func() {
+			err := as.Purchase(PurchaseInput{
+				Account: Account{
+					StoreFront: "143441",
+				},
+			})
+			Expect(err).To(MatchError(ErrLicenseAlreadyExists))
+		})
+	})
+
+	When("account already has a license for the app (HTTP 500 legacy)", func() {
 		BeforeEach(func() {
 			mockMachine.EXPECT().
 				MacAddress().
@@ -243,13 +270,40 @@ var _ = Describe("AppStore (Purchase)", func() {
 				}, nil)
 		})
 
-		It("returns error", func() {
+		It("returns license already exists error", func() {
 			err := as.Purchase(PurchaseInput{
 				Account: Account{
 					StoreFront: "143441",
 				},
 			})
-			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ErrLicenseAlreadyExists))
+		})
+	})
+
+	When("device verification fails", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:00:00:00:00:00", nil)
+
+			mockPurchaseClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[purchaseResult]{
+					StatusCode: 200,
+					Data: purchaseResult{
+						FailureType:     FailureTypeDeviceVerificationFailed,
+						CustomerMessage: "Your device or computer could not be verified. Contact support for assistance.",
+					},
+				}, nil)
+		})
+
+		It("returns password token expired error", func() {
+			err := as.Purchase(PurchaseInput{
+				Account: Account{
+					StoreFront: "143441",
+				},
+			})
+			Expect(err).To(MatchError(ErrPasswordTokenExpired))
 		})
 	})
 

--- a/pkg/appstore/appstore_purchase_test.go
+++ b/pkg/appstore/appstore_purchase_test.go
@@ -152,6 +152,32 @@ var _ = Describe("AppStore (Purchase)", func() {
 		})
 	})
 
+	When("customer message indicates password has changed", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:00:00:00:00:00", nil)
+
+			mockPurchaseClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[purchaseResult]{
+					Data: purchaseResult{
+						FailureType:     "some_other_failure",
+						CustomerMessage: CustomerMessagePasswordChanged,
+					},
+				}, nil)
+		})
+
+		It("returns password token expired error", func() {
+			err := as.Purchase(PurchaseInput{
+				Account: Account{
+					StoreFront: "143441",
+				},
+			})
+			Expect(err).To(MatchError(ErrPasswordTokenExpired))
+		})
+	})
+
 	When("store API returns customer error message", func() {
 		BeforeEach(func() {
 			mockMachine.EXPECT().

--- a/pkg/appstore/constants.go
+++ b/pkg/appstore/constants.go
@@ -18,8 +18,8 @@ const (
 	PrivateInitDomain = "init." + iTunesAPIDomain
 	PrivateInitPath   = "/bag.xml"
 
-	PrivateAppStoreAPIDomain            = "buy." + iTunesAPIDomain
-	PrivateAppStoreAPIPathAuthenticate = "https://" + PrivateAppStoreAPIDomain + "/WebObjects/MZFinance.woa/wa/authenticate"
+	PrivateAppStoreAPIDomain           = "buy." + iTunesAPIDomain
+	PrivateAppStoreAPIPathAuthenticate = "/WebObjects/MZFinance.woa/wa/authenticate"
 	PrivateAppStoreAPIPathPurchase     = "/WebObjects/MZFinance.woa/wa/buyProduct"
 	PrivateAppStoreAPIPathDownload = "/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct"
 

--- a/pkg/appstore/constants.go
+++ b/pkg/appstore/constants.go
@@ -22,6 +22,7 @@ const (
 
 	PrivateAppStoreAPIDomain           = "buy." + iTunesAPIDomain
 	PrivateAppStoreAPIPathAuthenticate = "/WebObjects/MZFinance.woa/wa/authenticate"
+	DefaultAuthEndpoint                = "https://" + PrivateAppStoreAPIDomain + PrivateAppStoreAPIPathAuthenticate
 	PrivateAppStoreAPIPathPurchase     = "/WebObjects/MZFinance.woa/wa/buyProduct"
 	PrivateAppStoreAPIPathDownload = "/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct"
 

--- a/pkg/appstore/constants.go
+++ b/pkg/appstore/constants.go
@@ -1,10 +1,12 @@
 package appstore
 
 const (
-	FailureTypeInvalidCredentials     = "-5000"
-	FailureTypePasswordTokenExpired   = "2034"
-	FailureTypeLicenseNotFound        = "9610"
-	FailureTypeTemporarilyUnavailable = "2059"
+	FailureTypeInvalidCredentials      = "-5000"
+	FailureTypePasswordTokenExpired    = "2034"
+	FailureTypeLicenseNotFound         = "9610"
+	FailureTypeTemporarilyUnavailable  = "2059"
+	FailureTypeLicenseAlreadyExists    = "5002"
+	FailureTypeDeviceVerificationFailed = "1008"
 
 	CustomerMessageBadLogin             = "MZFinance.BadLogin.Configurator_message"
 	CustomerMessageAccountDisabled      = "Your account is disabled."

--- a/pkg/appstore/constants.go
+++ b/pkg/appstore/constants.go
@@ -9,6 +9,7 @@ const (
 	CustomerMessageBadLogin             = "MZFinance.BadLogin.Configurator_message"
 	CustomerMessageAccountDisabled      = "Your account is disabled."
 	CustomerMessageSubscriptionRequired = "Subscription Required"
+	CustomerMessagePasswordChanged      = "Your password has changed."
 
 	iTunesAPIDomain     = "itunes.apple.com"
 	iTunesAPIPathSearch = "/search"
@@ -17,8 +18,9 @@ const (
 	PrivateInitDomain = "init." + iTunesAPIDomain
 	PrivateInitPath   = "/bag.xml"
 
-	PrivateAppStoreAPIDomain       = "buy." + iTunesAPIDomain
-	PrivateAppStoreAPIPathPurchase = "/WebObjects/MZFinance.woa/wa/buyProduct"
+	PrivateAppStoreAPIDomain            = "buy." + iTunesAPIDomain
+	PrivateAppStoreAPIPathAuthenticate = "https://" + PrivateAppStoreAPIDomain + "/WebObjects/MZFinance.woa/wa/authenticate"
+	PrivateAppStoreAPIPathPurchase     = "/WebObjects/MZFinance.woa/wa/buyProduct"
 	PrivateAppStoreAPIPathDownload = "/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct"
 
 	HTTPHeaderStoreFront = "X-Set-Apple-Store-Front"


### PR DESCRIPTION
The retry logic in purchase, download, get-version-metadata, and list-versions called Login() without an Endpoint when re-authenticating after a password token expiry. This caused re-auth to silently fail because the auth endpoint was empty.

Add Bag() call before Login() in all retry blocks to resolve the auth endpoint dynamically
Fall back to hardcoded auth endpoint when bag.xml omits authenticateAccount
Detect "Your password has changed." customer message as a token expiry trigger alongside failure type 2034
Increase download retry attempts to 3 to handle license-required → token-expired chain