### PR TITLE
Fix IPA generated by ipatool not installable via itms-services

### DIFF
--- a/pkg/appstore/appstore_replicate_sinf.go
+++ b/pkg/appstore/appstore_replicate_sinf.go
@@ -135,16 +135,16 @@ func (t *appstore) replicateSinfFromInfo(info packageInfo, zip *zip.Writer, sinf
 
 func (t *appstore) replicateZip(src *zip.ReadCloser, dst *zip.Writer) error {
 	for _, file := range src.File {
-		srcFile, err := file.OpenRaw()
+		srcFile, err := file.Open()
 		if err != nil {
-			return fmt.Errorf("failed to open raw file: %w", err)
+			return fmt.Errorf("failed to open file: %w", err)
 		}
 
 		header := file.FileHeader
-		dstFile, err := dst.CreateRaw(&header)
+		dstFile, err := dst.CreateHeader(&header)
 
 		if err != nil {
-			return fmt.Errorf("failed to create raw file: %w", err)
+			return fmt.Errorf("failed to create file: %w", err)
 		}
 
 		_, err = io.Copy(dstFile, srcFile)

--- a/pkg/appstore/appstore_replicate_sinf.go
+++ b/pkg/appstore/appstore_replicate_sinf.go
@@ -135,21 +135,29 @@ func (t *appstore) replicateSinfFromInfo(info packageInfo, zip *zip.Writer, sinf
 
 func (t *appstore) replicateZip(src *zip.ReadCloser, dst *zip.Writer) error {
 	for _, file := range src.File {
-		srcFile, err := file.Open()
-		if err != nil {
-			return fmt.Errorf("failed to open file: %w", err)
-		}
+		err := func() error {
+			srcFile, err := file.Open()
+			if err != nil {
+				return fmt.Errorf("failed to open file: %w", err)
+			}
+			defer srcFile.Close()
 
-		header := file.FileHeader
-		dstFile, err := dst.CreateHeader(&header)
+			header := file.FileHeader
+			dstFile, err := dst.CreateHeader(&header)
 
-		if err != nil {
-			return fmt.Errorf("failed to create file: %w", err)
-		}
+			if err != nil {
+				return fmt.Errorf("failed to create file: %w", err)
+			}
 
-		_, err = io.Copy(dstFile, srcFile)
+			_, err = io.Copy(dstFile, srcFile)
+			if err != nil {
+				return fmt.Errorf("failed to copy file: %w", err)
+			}
+
+			return nil
+		}()
 		if err != nil {
-			return fmt.Errorf("failed to copy file: %w", err)
+			return err
 		}
 	}
 


### PR DESCRIPTION
- **fix: generate ipa compatible with itms-services installation**
- **Close zip entry readers during replication**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes IPA generation so it installs via itms-services. Switches to standard zip APIs and ensures each entry is closed to produce a valid archive.

- **Bug Fixes**
  - Use `archive/zip` `Open` + `CreateHeader` instead of raw methods to write correct CRC/compression metadata.
  - Scope per-file replication and `defer Close()` to prevent leaks and incomplete copies.

<sup>Written for commit 07a426fd3d0cb4e6a968f8e42e559c4aca8973a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

