### PR TITLE
chore(repo): remove Patreon funding option

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
 # github: [majd]
-patreon: majd_dev
+# patreon: majd_dev


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the Patreon funding option to stop showing the Patreon link on the repository.
Commented out `patreon: majd_dev` in `.github/FUNDING.yml`.

<sup>Written for commit c06bf4250cd08728234cf70de6d8836f4b02a408. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

