### PR TITLE
chore(repo): delete .github/FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-# github: [majd]
-# patreon: majd_dev


### PR DESCRIPTION
This pull request removes the funding configuration from the repository by deleting the relevant lines in the `.github/FUNDING.yml` file.

- Removed GitHub and Patreon funding links from `.github/FUNDING.yml`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the repository funding configuration by deleting .github/FUNDING.yml to stop showing GitHub Sponsors and Patreon links.

<sup>Written for commit 43e467b98d6cf0ffe915ee91aaff47ea8d986caf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

