### PR TITLE
BUGFIX: `ERR error="invalid country code` feat: add --country flag and improve search/download robustness

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        command: [auth, download, purchase, search]
+        command: [auth, download, purchase, search, list-versions, get-version-metadata]
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Global Flags:
 Use "ipatool auth [command] --help" for more information about a command.
 ```
 
-To search for apps on the App Store, use the `search` command.
+To search for apps on the App Store, use the `search` command. (Note: login is optional for this command)
 
 ```
 Search for iOS apps available on the App Store
@@ -71,9 +71,10 @@ Usage:
   ipatool search <term> [flags]
 
 Flags:
-  -h, --help        help for search
-  -l, --limit int   maximum amount of search results to retrieve (default 5)
-
+  -c, --country string   country code to search in (e.g. US, GB); defaults to the account's country
+  -h, --help             help for search
+  -l, --limit int        maximum amount of search results to retrieve (default 5)
+```
 Global Flags:
       --format format     sets output format for command; can be 'text', 'json' (default text)
       --non-interactive   run in non-interactive session
@@ -90,8 +91,9 @@ Usage:
 
 Flags:
   -b, --bundle-identifier string   Bundle identifier of the target iOS app (required)
+  -c, --country string             Country code to use for lookup (e.g. US, GB); defaults to the account's country
   -h, --help                       help for purchase
-
+```
 Global Flags:
       --format format     sets output format for command; can be 'text', 'json' (default text)
       --non-interactive   run in non-interactive session
@@ -109,8 +111,9 @@ Usage:
 Flags:
   -i, --app-id int                 ID of the target iOS app (required)
   -b, --bundle-identifier string   The bundle identifier of the target iOS app (overrides the app ID)
+  -c, --country string             Country code to use for lookup (e.g. US, GB); defaults to the account's country
   -h, --help                       help for list-versions
-
+```
 Global Flags:
       --format format                sets output format for command; can be 'text', 'json' (default text)
       --keychain-passphrase string   passphrase for unlocking keychain
@@ -129,11 +132,12 @@ Usage:
 Flags:
   -i, --app-id int                   ID of the target iOS app (required)
   -b, --bundle-identifier string     The bundle identifier of the target iOS app (overrides the app ID)
+  -c, --country string               Country code to use for lookup (e.g. US, GB); defaults to the account's country
       --external-version-id string   External version identifier of the target iOS app (defaults to latest version when not specified)
   -h, --help                         help for download
   -o, --output string                The destination path of the downloaded app package
       --purchase                     Obtain a license for the app if needed
-
+```
 Global Flags:
       --format format                sets output format for command; can be 'text', 'json' (default text)
       --keychain-passphrase string   passphrase for unlocking keychain
@@ -152,9 +156,10 @@ Usage:
 Flags:
   -i, --app-id int                   ID of the target iOS app (required)
   -b, --bundle-identifier string     The bundle identifier of the target iOS app (overrides the app ID)
+  -c, --country string               Country code to use for lookup (e.g. US, GB); defaults to the account's country
       --external-version-id string   External version identifier of the target iOS app (required)
   -h, --help                         help for get-version-metadata
-
+```
 Global Flags:
       --format format                sets output format for command; can be 'text', 'json' (default text)
       --keychain-passphrase string   passphrase for unlocking keychain

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -47,7 +47,7 @@ func loginCmd() *cobra.Command {
 		Use:   "login",
 		Short: "Login to the App Store",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			interactive := cmd.Context().Value("interactive").(bool)
+			interactive, _ := cmd.Context().Value(interactiveKey).(bool)
 
 			if password == "" && !interactive {
 				return errors.New("password is required when not running in interactive mode; use the \"--password\" flag")

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -20,6 +20,7 @@ func downloadCmd() *cobra.Command {
 		appID             int64
 		bundleID          string
 		externalVersionID string
+		country           string
 	)
 
 	cmd := &cobra.Command{
@@ -36,13 +37,19 @@ func downloadCmd() *cobra.Command {
 
 			return retry.Do(func() error {
 				infoResult, err := dependencies.AppStore.AccountInfo()
-				if err != nil {
-					return err
+				if err == nil {
+					acc = infoResult.Account
 				}
 
-				acc = infoResult.Account
+				if country == "" && acc.StoreFront == "" {
+					country = "US"
+				}
 
 				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
+					if acc.Email == "" {
+						return errors.New("login is required to download apps; please use the \"auth login\" command")
+					}
+
 					bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
 					if err != nil {
 						return fmt.Errorf("failed to get bag: %w", err)
@@ -62,12 +69,20 @@ func downloadCmd() *cobra.Command {
 
 				app := appstore.App{ID: appID}
 				if bundleID != "" {
-					lookupResult, err := dependencies.AppStore.Lookup(appstore.LookupInput{Account: acc, BundleID: bundleID})
+					lookupResult, err := dependencies.AppStore.Lookup(appstore.LookupInput{
+						Account:     acc,
+						BundleID:    bundleID,
+						CountryCode: country,
+					})
 					if err != nil {
 						return err
 					}
 
 					app = lookupResult.App
+				}
+
+				if acc.Email == "" {
+					return errors.New("login is required to download apps; please use the \"auth login\" command")
 				}
 
 				if errors.Is(lastErr, appstore.ErrLicenseRequired) {
@@ -81,7 +96,7 @@ func downloadCmd() *cobra.Command {
 						Msg("purchase")
 				}
 
-				interactive, _ := cmd.Context().Value("interactive").(bool)
+				interactive, _ := cmd.Context().Value(interactiveKey).(bool)
 				var progress *progressbar.ProgressBar
 				if interactive {
 					progress = progressbar.NewOptions64(1,
@@ -103,6 +118,9 @@ func downloadCmd() *cobra.Command {
 				out, err := dependencies.AppStore.Download(appstore.DownloadInput{
 					Account: acc, App: app, OutputPath: outputPath, Progress: progress, ExternalVersionID: externalVersionID})
 				if err != nil {
+					if errors.Is(err, appstore.ErrLicenseRequired) && !acquireLicense {
+						return fmt.Errorf("%w; please use the \"--purchase\" flag to obtain a license for this app", err)
+					}
 					return err
 				}
 
@@ -145,6 +163,7 @@ func downloadCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "The destination path of the downloaded app package")
 	cmd.Flags().StringVar(&externalVersionID, "external-version-id", "", "External version identifier of the target iOS app (defaults to latest version when not specified)")
 	cmd.Flags().BoolVar(&acquireLicense, "purchase", false, "Obtain a license for the app if needed")
+	cmd.Flags().StringVarP(&country, "country", "c", "", "Country code to use for lookup (e.g. US, GB); defaults to the account's country")
 
 	return cmd
 }

--- a/cmd/get_version_metadata.go
+++ b/cmd/get_version_metadata.go
@@ -16,6 +16,7 @@ func getVersionMetadataCmd() *cobra.Command {
 		appID             int64
 		bundleID          string
 		externalVersionID string
+		country           string
 	)
 
 	cmd := &cobra.Command{
@@ -31,13 +32,19 @@ func getVersionMetadataCmd() *cobra.Command {
 
 			return retry.Do(func() error {
 				infoResult, err := dependencies.AppStore.AccountInfo()
-				if err != nil {
-					return err
+				if err == nil {
+					acc = infoResult.Account
 				}
 
-				acc = infoResult.Account
+				if country == "" && acc.StoreFront == "" {
+					country = "US"
+				}
 
 				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
+					if acc.Email == "" {
+						return errors.New("login is required to get version metadata; please use the \"auth login\" command")
+					}
+
 					bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
 					if err != nil {
 						return fmt.Errorf("failed to get bag: %w", err)
@@ -57,12 +64,20 @@ func getVersionMetadataCmd() *cobra.Command {
 
 				app := appstore.App{ID: appID}
 				if bundleID != "" {
-					lookupResult, err := dependencies.AppStore.Lookup(appstore.LookupInput{Account: acc, BundleID: bundleID})
+					lookupResult, err := dependencies.AppStore.Lookup(appstore.LookupInput{
+						Account:     acc,
+						BundleID:    bundleID,
+						CountryCode: country,
+					})
 					if err != nil {
 						return err
 					}
 
 					app = lookupResult.App
+				}
+
+				if acc.Email == "" {
+					return errors.New("login is required to get version metadata; please use the \"auth login\" command")
 				}
 
 				out, err := dependencies.AppStore.GetVersionMetadata(appstore.GetVersionMetadataInput{
@@ -99,6 +114,7 @@ func getVersionMetadataCmd() *cobra.Command {
 	cmd.Flags().Int64VarP(&appID, "app-id", "i", 0, "ID of the target iOS app (required)")
 	cmd.Flags().StringVarP(&bundleID, "bundle-identifier", "b", "", "The bundle identifier of the target iOS app (overrides the app ID)")
 	cmd.Flags().StringVar(&externalVersionID, "external-version-id", "", "External version identifier of the target iOS app (required)")
+	cmd.Flags().StringVarP(&country, "country", "c", "", "Country code to use for lookup (e.g. US, GB); defaults to the account's country")
 
 	_ = cmd.MarkFlagRequired("external-version-id")
 

--- a/cmd/list_versions.go
+++ b/cmd/list_versions.go
@@ -15,6 +15,7 @@ func ListVersionsCmd() *cobra.Command {
 	var (
 		appID    int64
 		bundleID string
+		country  string
 	)
 
 	cmd := &cobra.Command{
@@ -30,13 +31,19 @@ func ListVersionsCmd() *cobra.Command {
 
 			return retry.Do(func() error {
 				infoResult, err := dependencies.AppStore.AccountInfo()
-				if err != nil {
-					return err
+				if err == nil {
+					acc = infoResult.Account
 				}
 
-				acc = infoResult.Account
+				if country == "" && acc.StoreFront == "" {
+					country = "US"
+				}
 
 				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
+					if acc.Email == "" {
+						return errors.New("login is required to list versions; please use the \"auth login\" command")
+					}
+
 					bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
 					if err != nil {
 						return fmt.Errorf("failed to get bag: %w", err)
@@ -56,12 +63,20 @@ func ListVersionsCmd() *cobra.Command {
 
 				app := appstore.App{ID: appID}
 				if bundleID != "" {
-					lookupResult, err := dependencies.AppStore.Lookup(appstore.LookupInput{Account: acc, BundleID: bundleID})
+					lookupResult, err := dependencies.AppStore.Lookup(appstore.LookupInput{
+						Account:     acc,
+						BundleID:    bundleID,
+						CountryCode: country,
+					})
 					if err != nil {
 						return err
 					}
 
 					app = lookupResult.App
+				}
+
+				if acc.Email == "" {
+					return errors.New("login is required to list versions; please use the \"auth login\" command")
 				}
 
 				out, err := dependencies.AppStore.ListVersions(appstore.ListVersionsInput{Account: acc, App: app})
@@ -92,6 +107,7 @@ func ListVersionsCmd() *cobra.Command {
 
 	cmd.Flags().Int64VarP(&appID, "app-id", "i", 0, "ID of the target iOS app (required)")
 	cmd.Flags().StringVarP(&bundleID, "bundle-identifier", "b", "", "The bundle identifier of the target iOS app (overrides the app ID)")
+	cmd.Flags().StringVarP(&country, "country", "c", "", "Country code to use for lookup (e.g. US, GB); defaults to the account's country")
 
 	return cmd
 }

--- a/cmd/purchase.go
+++ b/cmd/purchase.go
@@ -12,7 +12,10 @@ import (
 
 // nolint:wrapcheck
 func purchaseCmd() *cobra.Command {
-	var bundleID string
+	var (
+		bundleID string
+		country  string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "purchase",
@@ -23,13 +26,19 @@ func purchaseCmd() *cobra.Command {
 
 			return retry.Do(func() error {
 				infoResult, err := dependencies.AppStore.AccountInfo()
-				if err != nil {
-					return err
+				if err == nil {
+					acc = infoResult.Account
 				}
 
-				acc = infoResult.Account
+				if country == "" && acc.StoreFront == "" {
+					country = "US"
+				}
 
 				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
+					if acc.Email == "" {
+						return errors.New("login is required to purchase apps; please use the \"auth login\" command")
+					}
+
 					bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
 					if err != nil {
 						return fmt.Errorf("failed to get bag: %w", err)
@@ -47,9 +56,17 @@ func purchaseCmd() *cobra.Command {
 					acc = loginResult.Account
 				}
 
-				lookupResult, err := dependencies.AppStore.Lookup(appstore.LookupInput{Account: acc, BundleID: bundleID})
+				lookupResult, err := dependencies.AppStore.Lookup(appstore.LookupInput{
+					Account:     acc,
+					BundleID:    bundleID,
+					CountryCode: country,
+				})
 				if err != nil {
 					return err
+				}
+
+				if acc.Email == "" {
+					return errors.New("login is required to purchase apps; please use the \"auth login\" command")
 				}
 
 				err = dependencies.AppStore.Purchase(appstore.PurchaseInput{Account: acc, App: lookupResult.App})
@@ -78,6 +95,7 @@ func purchaseCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&bundleID, "bundle-identifier", "b", "", "Bundle identifier of the target iOS app (required)")
+	cmd.Flags().StringVarP(&country, "country", "c", "", "Country code to use for lookup (e.g. US, GB); defaults to the account's country")
 	_ = cmd.MarkFlagRequired("bundle-identifier")
 
 	return cmd

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -7,7 +7,10 @@ import (
 
 // nolint:wrapcheck
 func searchCmd() *cobra.Command {
-	var limit int64
+	var (
+		limit   int64
+		country string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "search <term>",
@@ -15,14 +18,20 @@ func searchCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			infoResult, err := dependencies.AppStore.AccountInfo()
-			if err != nil {
-				return err
+			var account appstore.Account
+			if err == nil {
+				account = infoResult.Account
+			}
+
+			if country == "" && account.StoreFront == "" {
+				country = "US"
 			}
 
 			output, err := dependencies.AppStore.Search(appstore.SearchInput{
-				Account: infoResult.Account,
-				Term:    args[0],
-				Limit:   limit,
+				Account:     account,
+				Term:        args[0],
+				Limit:       limit,
+				CountryCode: country,
 			})
 			if err != nil {
 				return err
@@ -38,6 +47,7 @@ func searchCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Int64VarP(&limit, "limit", "l", 5, "maximum amount of search results to retrieve")
+	cmd.Flags().StringVarP(&country, "country", "c", "", "country code to search in (e.g. US, GB); defaults to the account's country")
 
 	return cmd
 }

--- a/pkg/appstore/appstore_lookup.go
+++ b/pkg/appstore/appstore_lookup.go
@@ -10,8 +10,9 @@ import (
 )
 
 type LookupInput struct {
-	Account  Account
-	BundleID string
+	Account     Account
+	BundleID    string
+	CountryCode string
 }
 
 type LookupOutput struct {
@@ -19,9 +20,13 @@ type LookupOutput struct {
 }
 
 func (t *appstore) Lookup(input LookupInput) (LookupOutput, error) {
-	countryCode, err := countryCodeFromStoreFront(input.Account.StoreFront)
-	if err != nil {
-		return LookupOutput{}, fmt.Errorf("failed to resolve the country code: %w", err)
+	countryCode := input.CountryCode
+	if countryCode == "" {
+		var err error
+		countryCode, err = countryCodeFromStoreFront(input.Account.StoreFront)
+		if err != nil {
+			return LookupOutput{}, fmt.Errorf("failed to resolve the country code: %w", err)
+		}
 	}
 
 	request := t.lookupRequest(input.BundleID, countryCode)

--- a/pkg/appstore/appstore_lookup_test.go
+++ b/pkg/appstore/appstore_lookup_test.go
@@ -82,6 +82,14 @@ var _ = Describe("AppStore (Lookup)", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(app).To(Equal(LookupOutput{App: testApp}))
 			})
+
+			It("returns app with country code", func() {
+				app, err := as.Lookup(LookupInput{
+					CountryCode: "US",
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(app).To(Equal(LookupOutput{App: testApp}))
+			})
 		})
 	})
 

--- a/pkg/appstore/appstore_search.go
+++ b/pkg/appstore/appstore_search.go
@@ -11,9 +11,10 @@ import (
 )
 
 type SearchInput struct {
-	Account Account
-	Term    string
-	Limit   int64
+	Account     Account
+	Term        string
+	Limit       int64
+	CountryCode string
 }
 
 type SearchOutput struct {
@@ -22,9 +23,13 @@ type SearchOutput struct {
 }
 
 func (t *appstore) Search(input SearchInput) (SearchOutput, error) {
-	countryCode, err := countryCodeFromStoreFront(input.Account.StoreFront)
-	if err != nil {
-		return SearchOutput{}, fmt.Errorf("country code is invalid: %w", err)
+	countryCode := input.CountryCode
+	if countryCode == "" {
+		var err error
+		countryCode, err = countryCodeFromStoreFront(input.Account.StoreFront)
+		if err != nil {
+			return SearchOutput{}, fmt.Errorf("country code is invalid: %w", err)
+		}
 	}
 
 	request := t.searchRequest(input.Term, countryCode, input.Limit)

--- a/pkg/appstore/appstore_search_test.go
+++ b/pkg/appstore/appstore_search_test.go
@@ -74,6 +74,14 @@ var _ = Describe("AppStore (Search)", func() {
 				Price:    testPrice,
 			}))
 		})
+
+		It("returns output with country code", func() {
+			out, err := as.Search(SearchInput{
+				CountryCode: "US",
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.Count).To(Equal(1))
+		})
 	})
 
 	When("store front is invalid", func() {


### PR DESCRIPTION
This is in response to the issue: https://github.com/majd/ipatool/issues/131

`BUGFIX: ERR error="invalid country code: could not infer country code from store front" success=false`
- Add --country flag to search, download, purchase, list-versions, and get-version-metadata commands.
- Make login optional for app identification phase (search, lookup).
- Fix panic in auth login by using the correct context key constant.
- Improve error message when ErrLicenseRequired is encountered in download, suggesting the use of --purchase.
- Fix country code mapping error when user is not logged in by defaulting to US store.
- Update README.md with new flags and usage instructions.
- Add unit tests for CountryCode in search and lookup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “invalid country code: could not infer country code from store front” error and adds a `--country` flag across commands. Makes search and lookup work without login and improves download robustness and error messages.

- New Features
  - Added `--country` flag to search, download, purchase, list-versions, and get-version-metadata. Uses the account’s storefront when available.
  - Made search and lookup work without login.

- Bug Fixes
  - Resolved country code errors when not logged in by using `--country` or defaulting to US; improved download errors to suggest `--purchase`.
  - Fixed panic in `auth login` (correct context key). Updated README, added unit tests for country handling, and expanded the integration test matrix to include `list-versions` and `get-version-metadata`.

<sup>Written for commit 4482c96b7b88b33aeb2958cc3682d4adafc8a155. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

