### PR TITLE
fix #464: fall back to redownload endpoint on FailureType 5002

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -47,7 +47,7 @@ func loginCmd() *cobra.Command {
 		Use:   "login",
 		Short: "Login to the App Store",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			interactive := cmd.Context().Value("interactive").(bool)
+			interactive, _ := cmd.Context().Value(interactiveKey).(bool)
 
 			if password == "" && !interactive {
 				return errors.New("password is required when not running in interactive mode; use the \"--password\" flag")

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -47,7 +47,7 @@ func loginCmd() *cobra.Command {
 		Use:   "login",
 		Short: "Login to the App Store",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			interactive, _ := cmd.Context().Value(interactiveKey).(bool)
+			interactive := cmd.Context().Value("interactive").(bool)
 
 			if password == "" && !interactive {
 				return errors.New("password is required when not running in interactive mode; use the \"--password\" flag")

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -81,7 +81,7 @@ func downloadCmd() *cobra.Command {
 						Msg("purchase")
 				}
 
-				interactive, _ := cmd.Context().Value("interactive").(bool)
+				interactive, _ := cmd.Context().Value(interactiveKey).(bool)
 				var progress *progressbar.ProgressBar
 				if interactive {
 					progress = progressbar.NewOptions64(1,

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -35,6 +35,11 @@ func downloadCmd() *cobra.Command {
 			purchased := false
 
 			return retry.Do(func() error {
+				bag, err := dependencies.AppStore.Bag(appstore.BagInput{})
+				if err != nil {
+					return fmt.Errorf("failed to get bag: %w", err)
+				}
+
 				infoResult, err := dependencies.AppStore.AccountInfo()
 				if err != nil {
 					return err
@@ -43,15 +48,10 @@ func downloadCmd() *cobra.Command {
 				acc = infoResult.Account
 
 				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
-					bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
-					if err != nil {
-						return fmt.Errorf("failed to get bag: %w", err)
-					}
-
 					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{
 						Email:    acc.Email,
 						Password: acc.Password,
-						Endpoint: bagOutput.AuthEndpoint,
+						Endpoint: bag.AuthEndpoint,
 					})
 					if err != nil {
 						return err
@@ -101,7 +101,7 @@ func downloadCmd() *cobra.Command {
 				}
 
 				out, err := dependencies.AppStore.Download(appstore.DownloadInput{
-					Account: acc, App: app, OutputPath: outputPath, Progress: progress, ExternalVersionID: externalVersionID})
+					Account: acc, App: app, OutputPath: outputPath, Progress: progress, ExternalVersionID: externalVersionID, Endpoint: bag.DownloadEndpoint})
 				if err != nil {
 					return err
 				}

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -81,7 +81,7 @@ func downloadCmd() *cobra.Command {
 						Msg("purchase")
 				}
 
-				interactive, _ := cmd.Context().Value(interactiveKey).(bool)
+				interactive, _ := cmd.Context().Value("interactive").(bool)
 				var progress *progressbar.ProgressBar
 				if interactive {
 					progress = progressbar.NewOptions64(1,

--- a/cmd/get_version_metadata.go
+++ b/cmd/get_version_metadata.go
@@ -30,6 +30,11 @@ func getVersionMetadataCmd() *cobra.Command {
 			var acc appstore.Account
 
 			return retry.Do(func() error {
+				bag, err := dependencies.AppStore.Bag(appstore.BagInput{})
+				if err != nil {
+					return fmt.Errorf("failed to get bag: %w", err)
+				}
+
 				infoResult, err := dependencies.AppStore.AccountInfo()
 				if err != nil {
 					return err
@@ -38,15 +43,10 @@ func getVersionMetadataCmd() *cobra.Command {
 				acc = infoResult.Account
 
 				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
-					bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
-					if err != nil {
-						return fmt.Errorf("failed to get bag: %w", err)
-					}
-
 					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{
 						Email:    acc.Email,
 						Password: acc.Password,
-						Endpoint: bagOutput.AuthEndpoint,
+						Endpoint: bag.AuthEndpoint,
 					})
 					if err != nil {
 						return err
@@ -69,6 +69,7 @@ func getVersionMetadataCmd() *cobra.Command {
 					Account:   acc,
 					App:       app,
 					VersionID: externalVersionID,
+					Endpoint:  bag.DownloadEndpoint,
 				})
 				if err != nil {
 					return err

--- a/cmd/list_versions.go
+++ b/cmd/list_versions.go
@@ -29,6 +29,11 @@ func ListVersionsCmd() *cobra.Command {
 			var acc appstore.Account
 
 			return retry.Do(func() error {
+				bag, err := dependencies.AppStore.Bag(appstore.BagInput{})
+				if err != nil {
+					return fmt.Errorf("failed to get bag: %w", err)
+				}
+
 				infoResult, err := dependencies.AppStore.AccountInfo()
 				if err != nil {
 					return err
@@ -37,15 +42,10 @@ func ListVersionsCmd() *cobra.Command {
 				acc = infoResult.Account
 
 				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
-					bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
-					if err != nil {
-						return fmt.Errorf("failed to get bag: %w", err)
-					}
-
 					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{
 						Email:    acc.Email,
 						Password: acc.Password,
-						Endpoint: bagOutput.AuthEndpoint,
+						Endpoint: bag.AuthEndpoint,
 					})
 					if err != nil {
 						return err
@@ -64,7 +64,7 @@ func ListVersionsCmd() *cobra.Command {
 					app = lookupResult.App
 				}
 
-				out, err := dependencies.AppStore.ListVersions(appstore.ListVersionsInput{Account: acc, App: app})
+				out, err := dependencies.AppStore.ListVersions(appstore.ListVersionsInput{Account: acc, App: app, Endpoint: bag.DownloadEndpoint})
 				if err != nil {
 					return err
 				}

--- a/pkg/appstore/appstore_bag.go
+++ b/pkg/appstore/appstore_bag.go
@@ -11,7 +11,8 @@ import (
 type BagInput struct{}
 
 type BagOutput struct {
-	AuthEndpoint string
+	AuthEndpoint     string
+	DownloadEndpoint string
 }
 
 func (t *appstore) Bag(input BagInput) (BagOutput, error) {
@@ -33,7 +34,8 @@ func (t *appstore) Bag(input BagInput) (BagOutput, error) {
 	}
 
 	return BagOutput{
-		AuthEndpoint: res.Data.URLBag.AuthEndpoint,
+		AuthEndpoint:     res.Data.URLBag.AuthEndpoint,
+		DownloadEndpoint: res.Data.URLBag.DownloadEndpoint,
 	}, nil
 }
 
@@ -42,7 +44,8 @@ type bagResult struct {
 }
 
 type urlBag struct {
-	AuthEndpoint string `plist:"authenticateAccount,omitempty"`
+	AuthEndpoint     string `plist:"authenticateAccount,omitempty"`
+	DownloadEndpoint string `plist:"redownloadProduct,omitempty"`
 }
 
 func (*appstore) bagRequest(guid string) http.Request {

--- a/pkg/appstore/appstore_bag_test.go
+++ b/pkg/appstore/appstore_bag_test.go
@@ -85,8 +85,11 @@ var _ = Describe("AppStore (Bag)", func() {
 		})
 	})
 
-	When("request is successful with authenticateAccount in urlBag", func() {
-		const testAuthEndpoint = "https://example.com"
+	When("request is successful with endpoints in urlBag", func() {
+		const (
+			testAuthEndpoint     = "https://example.com"
+			testDownloadEndpoint = "https://downloaddispatch.example.com/r/redownload"
+		)
 
 		BeforeEach(func() {
 			mockMachine.EXPECT().
@@ -105,7 +108,8 @@ var _ = Describe("AppStore (Bag)", func() {
 					StatusCode: gohttp.StatusOK,
 					Data: bagResult{
 						URLBag: urlBag{
-							AuthEndpoint: testAuthEndpoint,
+							AuthEndpoint:     testAuthEndpoint,
+							DownloadEndpoint: testDownloadEndpoint,
 						},
 					},
 				}, nil)
@@ -115,6 +119,7 @@ var _ = Describe("AppStore (Bag)", func() {
 			out, err := as.Bag(BagInput{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out.AuthEndpoint).To(Equal(testAuthEndpoint))
+			Expect(out.DownloadEndpoint).To(Equal(testDownloadEndpoint))
 		})
 	})
 

--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -24,6 +24,7 @@ type DownloadInput struct {
 	OutputPath        string
 	Progress          *progressbar.ProgressBar
 	ExternalVersionID string
+	Endpoint          string
 }
 
 type DownloadOutput struct {
@@ -39,7 +40,7 @@ func (t *appstore) Download(input DownloadInput) (DownloadOutput, error) {
 
 	guid := strings.ReplaceAll(strings.ToUpper(macAddr), ":", "")
 
-	req := t.downloadRequest(input.Account, input.App, guid, input.ExternalVersionID)
+	req := t.downloadRequest(input.Endpoint, input.Account, input.App, guid, input.ExternalVersionID)
 
 	res, err := t.downloadClient.Send(req)
 	if err != nil {
@@ -48,8 +49,7 @@ func (t *appstore) Download(input DownloadInput) (DownloadOutput, error) {
 
 	if res.Data.FailureType == FailureTypePasswordTokenExpired ||
 		res.Data.FailureType == FailureTypeSignInRequired ||
-		res.Data.FailureType == FailureTypeDeviceVerificationFailed ||
-		res.Data.FailureType == FailureTypeLicenseAlreadyExists {
+		res.Data.FailureType == FailureTypeDeviceVerificationFailed {
 		return DownloadOutput{}, ErrPasswordTokenExpired
 	}
 
@@ -172,7 +172,7 @@ func (t *appstore) downloadFile(src, dst string, progress *progressbar.ProgressB
 	return nil
 }
 
-func (*appstore) downloadRequest(acc Account, app App, guid string, externalVersionID string) http.Request {
+func (*appstore) downloadRequest(endpoint string, acc Account, app App, guid string, externalVersionID string) http.Request {
 	payload := map[string]interface{}{
 		"creditDisplay": "",
 		"guid":          guid,
@@ -180,16 +180,11 @@ func (*appstore) downloadRequest(acc Account, app App, guid string, externalVers
 	}
 
 	if externalVersionID != "" {
-		payload["externalVersionId"] = externalVersionID
-	}
-
-	podPrefix := ""
-	if acc.Pod != "" {
-		podPrefix = "p" + acc.Pod + "-"
+		payload["appExtVrsId"] = externalVersionID
 	}
 
 	return http.Request{
-		URL:            fmt.Sprintf("https://%s%s%s?guid=%s", podPrefix, PrivateAppStoreAPIDomain, PrivateAppStoreAPIPathDownload, guid),
+		URL:            fmt.Sprintf("%s?guid=%s", endpoint, guid),
 		Method:         http.MethodPOST,
 		ResponseFormat: http.ResponseFormatXML,
 		Headers: map[string]string{

--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -46,10 +46,18 @@ func (t *appstore) Download(input DownloadInput) (DownloadOutput, error) {
 		return DownloadOutput{}, fmt.Errorf("failed to send http request: %w", err)
 	}
 
+	if res.Data.FailureType == FailureTypeLicenseAlreadyExists {
+		req = t.redownloadRequest(input.Account, input.App, guid, input.ExternalVersionID)
+
+		res, err = t.downloadClient.Send(req)
+		if err != nil {
+			return DownloadOutput{}, fmt.Errorf("failed to send http request: %w", err)
+		}
+	}
+
 	if res.Data.FailureType == FailureTypePasswordTokenExpired ||
 		res.Data.FailureType == FailureTypeSignInRequired ||
-		res.Data.FailureType == FailureTypeDeviceVerificationFailed ||
-		res.Data.FailureType == FailureTypeLicenseAlreadyExists {
+		res.Data.FailureType == FailureTypeDeviceVerificationFailed {
 		return DownloadOutput{}, ErrPasswordTokenExpired
 	}
 
@@ -66,6 +74,10 @@ func (t *appstore) Download(input DownloadInput) (DownloadOutput, error) {
 	}
 
 	if len(res.Data.Items) == 0 {
+		if res.Data.CustomerMessage != "" {
+			return DownloadOutput{}, NewErrorWithMetadata(fmt.Errorf("received error: %s", res.Data.CustomerMessage), res)
+		}
+
 		return DownloadOutput{}, NewErrorWithMetadata(errors.New("invalid response"), res)
 	}
 
@@ -190,6 +202,36 @@ func (*appstore) downloadRequest(acc Account, app App, guid string, externalVers
 
 	return http.Request{
 		URL:            fmt.Sprintf("https://%s%s%s?guid=%s", podPrefix, PrivateAppStoreAPIDomain, PrivateAppStoreAPIPathDownload, guid),
+		Method:         http.MethodPOST,
+		ResponseFormat: http.ResponseFormatXML,
+		Headers: map[string]string{
+			"Content-Type": "application/x-apple-plist",
+			"iCloud-DSID":  acc.DirectoryServicesID,
+			"X-Dsid":       acc.DirectoryServicesID,
+		},
+		Payload: &http.XMLPayload{
+			Content: payload,
+		},
+	}
+}
+
+// redownloadRequest builds a request against the redownload dispatcher endpoint.
+// Some apps (notably Microsoft Teams/Office and other VPP-eligible apps) reject
+// the volumeStoreDownloadProduct path with FailureType 5002, but accept this
+// per-account redownload endpoint when the user already owns a license.
+func (*appstore) redownloadRequest(acc Account, app App, guid string, externalVersionID string) http.Request {
+	payload := map[string]interface{}{
+		"creditDisplay": "",
+		"guid":          guid,
+		"salableAdamId": app.ID,
+	}
+
+	if externalVersionID != "" {
+		payload["appExtVrsId"] = externalVersionID
+	}
+
+	return http.Request{
+		URL:            fmt.Sprintf("https://%s%s", PrivateDownloadDispatchAPIDomain, PrivateDownloadDispatchAPIPath),
 		Method:         http.MethodPOST,
 		ResponseFormat: http.ResponseFormatXML,
 		Headers: map[string]string{

--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -46,18 +46,10 @@ func (t *appstore) Download(input DownloadInput) (DownloadOutput, error) {
 		return DownloadOutput{}, fmt.Errorf("failed to send http request: %w", err)
 	}
 
-	if res.Data.FailureType == FailureTypeLicenseAlreadyExists {
-		req = t.redownloadRequest(input.Account, input.App, guid, input.ExternalVersionID)
-
-		res, err = t.downloadClient.Send(req)
-		if err != nil {
-			return DownloadOutput{}, fmt.Errorf("failed to send http request: %w", err)
-		}
-	}
-
 	if res.Data.FailureType == FailureTypePasswordTokenExpired ||
 		res.Data.FailureType == FailureTypeSignInRequired ||
-		res.Data.FailureType == FailureTypeDeviceVerificationFailed {
+		res.Data.FailureType == FailureTypeDeviceVerificationFailed ||
+		res.Data.FailureType == FailureTypeLicenseAlreadyExists {
 		return DownloadOutput{}, ErrPasswordTokenExpired
 	}
 
@@ -74,10 +66,6 @@ func (t *appstore) Download(input DownloadInput) (DownloadOutput, error) {
 	}
 
 	if len(res.Data.Items) == 0 {
-		if res.Data.CustomerMessage != "" {
-			return DownloadOutput{}, NewErrorWithMetadata(fmt.Errorf("received error: %s", res.Data.CustomerMessage), res)
-		}
-
 		return DownloadOutput{}, NewErrorWithMetadata(errors.New("invalid response"), res)
 	}
 
@@ -202,36 +190,6 @@ func (*appstore) downloadRequest(acc Account, app App, guid string, externalVers
 
 	return http.Request{
 		URL:            fmt.Sprintf("https://%s%s%s?guid=%s", podPrefix, PrivateAppStoreAPIDomain, PrivateAppStoreAPIPathDownload, guid),
-		Method:         http.MethodPOST,
-		ResponseFormat: http.ResponseFormatXML,
-		Headers: map[string]string{
-			"Content-Type": "application/x-apple-plist",
-			"iCloud-DSID":  acc.DirectoryServicesID,
-			"X-Dsid":       acc.DirectoryServicesID,
-		},
-		Payload: &http.XMLPayload{
-			Content: payload,
-		},
-	}
-}
-
-// redownloadRequest builds a request against the redownload dispatcher endpoint.
-// Some apps (notably Microsoft Teams/Office and other VPP-eligible apps) reject
-// the volumeStoreDownloadProduct path with FailureType 5002, but accept this
-// per-account redownload endpoint when the user already owns a license.
-func (*appstore) redownloadRequest(acc Account, app App, guid string, externalVersionID string) http.Request {
-	payload := map[string]interface{}{
-		"creditDisplay": "",
-		"guid":          guid,
-		"salableAdamId": app.ID,
-	}
-
-	if externalVersionID != "" {
-		payload["appExtVrsId"] = externalVersionID
-	}
-
-	return http.Request{
-		URL:            fmt.Sprintf("https://%s%s", PrivateDownloadDispatchAPIDomain, PrivateDownloadDispatchAPIPath),
 		Method:         http.MethodPOST,
 		ResponseFormat: http.ResponseFormatXML,
 		Headers: map[string]string{

--- a/pkg/appstore/appstore_download_test.go
+++ b/pkg/appstore/appstore_download_test.go
@@ -190,6 +190,43 @@ var _ = Describe("AppStore (Download)", func() {
 		})
 	})
 
+	When("primary endpoint returns FailureType 5002", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("", nil)
+
+			gomock.InOrder(
+				mockDownloadClient.EXPECT().
+					Send(gomock.Any()).
+					Do(func(req http.Request) {
+						Expect(req.URL).To(ContainSubstring(PrivateAppStoreAPIPathDownload))
+					}).
+					Return(http.Result[downloadResult]{
+						Data: downloadResult{
+							FailureType: FailureTypeLicenseAlreadyExists,
+						},
+					}, nil),
+				mockDownloadClient.EXPECT().
+					Send(gomock.Any()).
+					Do(func(req http.Request) {
+						Expect(req.URL).To(ContainSubstring(PrivateDownloadDispatchAPIDomain))
+					}).
+					Return(http.Result[downloadResult]{
+						Data: downloadResult{
+							FailureType: "secondary-failure",
+						},
+					}, nil),
+			)
+		})
+
+		It("falls back to the redownload endpoint and surfaces its error", func() {
+			_, err := as.Download(DownloadInput{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("secondary-failure"))
+		})
+	})
+
 	When("store API returns error", func() {
 		BeforeEach(func() {
 			mockMachine.EXPECT().

--- a/pkg/appstore/appstore_download_test.go
+++ b/pkg/appstore/appstore_download_test.go
@@ -97,10 +97,10 @@ var _ = Describe("AppStore (Download)", func() {
 		})
 	})
 
-	When("request uses a custom pod", func() {
+	When("request is sent", func() {
 		const (
-			testPod  = "42"
-			testGUID = "001122334455"
+			testEndpoint = "https://downloaddispatch.example.com/r/redownload"
+			testGUID     = "001122334455"
 		)
 
 		BeforeEach(func() {
@@ -111,18 +111,13 @@ var _ = Describe("AppStore (Download)", func() {
 			mockDownloadClient.EXPECT().
 				Send(gomock.Any()).
 				Do(func(req http.Request) {
-					expectedURL := "https://p" + testPod + "-" + PrivateAppStoreAPIDomain + PrivateAppStoreAPIPathDownload + "?guid=" + testGUID
-					Expect(req.URL).To(Equal(expectedURL))
+					Expect(req.URL).To(Equal(testEndpoint + "?guid=" + testGUID))
 				}).
 				Return(http.Result[downloadResult]{}, errors.New(""))
 		})
 
-		It("sends the download request to the pod-specific host", func() {
-			_, err := as.Download(DownloadInput{
-				Account: Account{
-					Pod: testPod,
-				},
-			})
+		It("sends the download request to the endpoint provided by the caller", func() {
+			_, err := as.Download(DownloadInput{Endpoint: testEndpoint})
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/pkg/appstore/appstore_download_test.go
+++ b/pkg/appstore/appstore_download_test.go
@@ -190,43 +190,6 @@ var _ = Describe("AppStore (Download)", func() {
 		})
 	})
 
-	When("primary endpoint returns FailureType 5002", func() {
-		BeforeEach(func() {
-			mockMachine.EXPECT().
-				MacAddress().
-				Return("", nil)
-
-			gomock.InOrder(
-				mockDownloadClient.EXPECT().
-					Send(gomock.Any()).
-					Do(func(req http.Request) {
-						Expect(req.URL).To(ContainSubstring(PrivateAppStoreAPIPathDownload))
-					}).
-					Return(http.Result[downloadResult]{
-						Data: downloadResult{
-							FailureType: FailureTypeLicenseAlreadyExists,
-						},
-					}, nil),
-				mockDownloadClient.EXPECT().
-					Send(gomock.Any()).
-					Do(func(req http.Request) {
-						Expect(req.URL).To(ContainSubstring(PrivateDownloadDispatchAPIDomain))
-					}).
-					Return(http.Result[downloadResult]{
-						Data: downloadResult{
-							FailureType: "secondary-failure",
-						},
-					}, nil),
-			)
-		})
-
-		It("falls back to the redownload endpoint and surfaces its error", func() {
-			_, err := as.Download(DownloadInput{})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("secondary-failure"))
-		})
-	})
-
 	When("store API returns error", func() {
 		BeforeEach(func() {
 			mockMachine.EXPECT().

--- a/pkg/appstore/appstore_get_version_metadata.go
+++ b/pkg/appstore/appstore_get_version_metadata.go
@@ -35,15 +35,6 @@ func (t *appstore) GetVersionMetadata(input GetVersionMetadataInput) (GetVersion
 		return GetVersionMetadataOutput{}, fmt.Errorf("failed to send http request: %w", err)
 	}
 
-	if res.Data.FailureType == FailureTypeLicenseAlreadyExists {
-		req = t.redownloadRequest(input.Account, input.App, guid, input.VersionID)
-
-		res, err = t.downloadClient.Send(req)
-		if err != nil {
-			return GetVersionMetadataOutput{}, fmt.Errorf("failed to send http request: %w", err)
-		}
-	}
-
 	if res.Data.FailureType == FailureTypePasswordTokenExpired || res.Data.FailureType == FailureTypeSignInRequired {
 		return GetVersionMetadataOutput{}, ErrPasswordTokenExpired
 	}
@@ -61,10 +52,6 @@ func (t *appstore) GetVersionMetadata(input GetVersionMetadataInput) (GetVersion
 	}
 
 	if len(res.Data.Items) == 0 {
-		if res.Data.CustomerMessage != "" {
-			return GetVersionMetadataOutput{}, NewErrorWithMetadata(fmt.Errorf("received error: %s", res.Data.CustomerMessage), res)
-		}
-
 		return GetVersionMetadataOutput{}, NewErrorWithMetadata(errors.New("invalid response"), res)
 	}
 

--- a/pkg/appstore/appstore_get_version_metadata.go
+++ b/pkg/appstore/appstore_get_version_metadata.go
@@ -13,6 +13,7 @@ type GetVersionMetadataInput struct {
 	Account   Account
 	App       App
 	VersionID string
+	Endpoint  string
 }
 
 type GetVersionMetadataOutput struct {
@@ -28,7 +29,7 @@ func (t *appstore) GetVersionMetadata(input GetVersionMetadataInput) (GetVersion
 
 	guid := strings.ReplaceAll(strings.ToUpper(macAddr), ":", "")
 
-	req := t.getVersionMetadataRequest(input.Account, input.App, guid, input.VersionID)
+	req := t.getVersionMetadataRequest(input.Endpoint, input.Account, input.App, guid, input.VersionID)
 	res, err := t.downloadClient.Send(req)
 
 	if err != nil {
@@ -68,21 +69,16 @@ func (t *appstore) GetVersionMetadata(input GetVersionMetadataInput) (GetVersion
 	return GetVersionMetadataOutput(metadata), nil
 }
 
-func (t *appstore) getVersionMetadataRequest(acc Account, app App, guid string, version string) http.Request {
+func (t *appstore) getVersionMetadataRequest(endpoint string, acc Account, app App, guid string, version string) http.Request {
 	payload := map[string]interface{}{
-		"creditDisplay":     "",
-		"guid":              guid,
-		"salableAdamId":     app.ID,
-		"externalVersionId": version,
-	}
-
-	podPrefix := ""
-	if acc.Pod != "" {
-		podPrefix = "p" + acc.Pod + "-"
+		"creditDisplay": "",
+		"guid":          guid,
+		"salableAdamId": app.ID,
+		"appExtVrsId":   version,
 	}
 
 	return http.Request{
-		URL:            fmt.Sprintf("https://%s%s%s?guid=%s", podPrefix, PrivateAppStoreAPIDomain, PrivateAppStoreAPIPathDownload, guid),
+		URL:            fmt.Sprintf("%s?guid=%s", endpoint, guid),
 		Method:         http.MethodPOST,
 		ResponseFormat: http.ResponseFormatXML,
 		Headers: map[string]string{

--- a/pkg/appstore/appstore_get_version_metadata.go
+++ b/pkg/appstore/appstore_get_version_metadata.go
@@ -35,6 +35,15 @@ func (t *appstore) GetVersionMetadata(input GetVersionMetadataInput) (GetVersion
 		return GetVersionMetadataOutput{}, fmt.Errorf("failed to send http request: %w", err)
 	}
 
+	if res.Data.FailureType == FailureTypeLicenseAlreadyExists {
+		req = t.redownloadRequest(input.Account, input.App, guid, input.VersionID)
+
+		res, err = t.downloadClient.Send(req)
+		if err != nil {
+			return GetVersionMetadataOutput{}, fmt.Errorf("failed to send http request: %w", err)
+		}
+	}
+
 	if res.Data.FailureType == FailureTypePasswordTokenExpired || res.Data.FailureType == FailureTypeSignInRequired {
 		return GetVersionMetadataOutput{}, ErrPasswordTokenExpired
 	}
@@ -52,6 +61,10 @@ func (t *appstore) GetVersionMetadata(input GetVersionMetadataInput) (GetVersion
 	}
 
 	if len(res.Data.Items) == 0 {
+		if res.Data.CustomerMessage != "" {
+			return GetVersionMetadataOutput{}, NewErrorWithMetadata(fmt.Errorf("received error: %s", res.Data.CustomerMessage), res)
+		}
+
 		return GetVersionMetadataOutput{}, NewErrorWithMetadata(errors.New("invalid response"), res)
 	}
 

--- a/pkg/appstore/appstore_get_version_metadata_test.go
+++ b/pkg/appstore/appstore_get_version_metadata_test.go
@@ -316,6 +316,43 @@ var _ = Describe("AppStore (GetVersionMetadata)", func() {
 		})
 	})
 
+	When("primary endpoint returns FailureType 5002", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			gomock.InOrder(
+				mockDownloadClient.EXPECT().
+					Send(gomock.Any()).
+					Do(func(req http.Request) {
+						Expect(req.URL).To(ContainSubstring(PrivateAppStoreAPIPathDownload))
+					}).
+					Return(http.Result[downloadResult]{
+						Data: downloadResult{
+							FailureType: FailureTypeLicenseAlreadyExists,
+						},
+					}, nil),
+				mockDownloadClient.EXPECT().
+					Send(gomock.Any()).
+					Do(func(req http.Request) {
+						Expect(req.URL).To(ContainSubstring(PrivateDownloadDispatchAPIDomain))
+					}).
+					Return(http.Result[downloadResult]{
+						Data: downloadResult{
+							FailureType: "secondary-failure",
+						},
+					}, nil),
+			)
+		})
+
+		It("falls back to the redownload endpoint and surfaces its error", func() {
+			_, err := as.GetVersionMetadata(GetVersionMetadataInput{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("secondary-failure"))
+		})
+	})
+
 	When("store API returns error", func() {
 		BeforeEach(func() {
 			mockMachine.EXPECT().

--- a/pkg/appstore/appstore_get_version_metadata_test.go
+++ b/pkg/appstore/appstore_get_version_metadata_test.go
@@ -222,10 +222,10 @@ var _ = Describe("AppStore (GetVersionMetadata)", func() {
 		})
 	})
 
-	When("request uses a custom pod", func() {
+	When("request is sent", func() {
 		const (
-			testPod  = "42"
-			testGUID = "001122334455"
+			testEndpoint = "https://downloaddispatch.example.com/r/redownload"
+			testGUID     = "001122334455"
 		)
 
 		BeforeEach(func() {
@@ -236,18 +236,13 @@ var _ = Describe("AppStore (GetVersionMetadata)", func() {
 			mockDownloadClient.EXPECT().
 				Send(gomock.Any()).
 				Do(func(req http.Request) {
-					expectedURL := "https://p" + testPod + "-" + PrivateAppStoreAPIDomain + PrivateAppStoreAPIPathDownload + "?guid=" + testGUID
-					Expect(req.URL).To(Equal(expectedURL))
+					Expect(req.URL).To(Equal(testEndpoint + "?guid=" + testGUID))
 				}).
 				Return(http.Result[downloadResult]{}, errors.New("request error"))
 		})
 
-		It("sends the request to the pod-specific host", func() {
-			_, err := as.GetVersionMetadata(GetVersionMetadataInput{
-				Account: Account{
-					Pod: testPod,
-				},
-			})
+		It("sends the request to the endpoint provided by the caller", func() {
+			_, err := as.GetVersionMetadata(GetVersionMetadataInput{Endpoint: testEndpoint})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to send http request"))
 		})

--- a/pkg/appstore/appstore_get_version_metadata_test.go
+++ b/pkg/appstore/appstore_get_version_metadata_test.go
@@ -316,43 +316,6 @@ var _ = Describe("AppStore (GetVersionMetadata)", func() {
 		})
 	})
 
-	When("primary endpoint returns FailureType 5002", func() {
-		BeforeEach(func() {
-			mockMachine.EXPECT().
-				MacAddress().
-				Return("00:11:22:33:44:55", nil)
-
-			gomock.InOrder(
-				mockDownloadClient.EXPECT().
-					Send(gomock.Any()).
-					Do(func(req http.Request) {
-						Expect(req.URL).To(ContainSubstring(PrivateAppStoreAPIPathDownload))
-					}).
-					Return(http.Result[downloadResult]{
-						Data: downloadResult{
-							FailureType: FailureTypeLicenseAlreadyExists,
-						},
-					}, nil),
-				mockDownloadClient.EXPECT().
-					Send(gomock.Any()).
-					Do(func(req http.Request) {
-						Expect(req.URL).To(ContainSubstring(PrivateDownloadDispatchAPIDomain))
-					}).
-					Return(http.Result[downloadResult]{
-						Data: downloadResult{
-							FailureType: "secondary-failure",
-						},
-					}, nil),
-			)
-		})
-
-		It("falls back to the redownload endpoint and surfaces its error", func() {
-			_, err := as.GetVersionMetadata(GetVersionMetadataInput{})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("secondary-failure"))
-		})
-	})
-
 	When("store API returns error", func() {
 		BeforeEach(func() {
 			mockMachine.EXPECT().

--- a/pkg/appstore/appstore_list_versions.go
+++ b/pkg/appstore/appstore_list_versions.go
@@ -9,8 +9,9 @@ import (
 )
 
 type ListVersionsInput struct {
-	Account Account
-	App     App
+	Account  Account
+	App      App
+	Endpoint string
 }
 
 type ListVersionsOutput struct {
@@ -26,7 +27,7 @@ func (t *appstore) ListVersions(input ListVersionsInput) (ListVersionsOutput, er
 
 	guid := strings.ReplaceAll(strings.ToUpper(macAddr), ":", "")
 
-	req := t.listVersionsRequest(input.Account, input.App, guid)
+	req := t.listVersionsRequest(input.Endpoint, input.Account, input.App, guid)
 	res, err := t.downloadClient.Send(req)
 
 	if err != nil {
@@ -76,20 +77,15 @@ func (t *appstore) ListVersions(input ListVersionsInput) (ListVersionsOutput, er
 	}, nil
 }
 
-func (t *appstore) listVersionsRequest(acc Account, app App, guid string) http.Request {
+func (t *appstore) listVersionsRequest(endpoint string, acc Account, app App, guid string) http.Request {
 	payload := map[string]interface{}{
 		"creditDisplay": "",
 		"guid":          guid,
 		"salableAdamId": app.ID,
 	}
 
-	podPrefix := ""
-	if acc.Pod != "" {
-		podPrefix = "p" + acc.Pod + "-"
-	}
-
 	return http.Request{
-		URL:            fmt.Sprintf("https://%s%s%s?guid=%s", podPrefix, PrivateAppStoreAPIDomain, PrivateAppStoreAPIPathDownload, guid),
+		URL:            fmt.Sprintf("%s?guid=%s", endpoint, guid),
 		Method:         http.MethodPOST,
 		ResponseFormat: http.ResponseFormatXML,
 		Headers: map[string]string{

--- a/pkg/appstore/appstore_list_versions.go
+++ b/pkg/appstore/appstore_list_versions.go
@@ -33,15 +33,6 @@ func (t *appstore) ListVersions(input ListVersionsInput) (ListVersionsOutput, er
 		return ListVersionsOutput{}, fmt.Errorf("failed to send http request: %w", err)
 	}
 
-	if res.Data.FailureType == FailureTypeLicenseAlreadyExists {
-		req = t.redownloadRequest(input.Account, input.App, guid, "")
-
-		res, err = t.downloadClient.Send(req)
-		if err != nil {
-			return ListVersionsOutput{}, fmt.Errorf("failed to send http request: %w", err)
-		}
-	}
-
 	if res.Data.FailureType == FailureTypePasswordTokenExpired || res.Data.FailureType == FailureTypeSignInRequired {
 		return ListVersionsOutput{}, ErrPasswordTokenExpired
 	}
@@ -59,10 +50,6 @@ func (t *appstore) ListVersions(input ListVersionsInput) (ListVersionsOutput, er
 	}
 
 	if len(res.Data.Items) == 0 {
-		if res.Data.CustomerMessage != "" {
-			return ListVersionsOutput{}, NewErrorWithMetadata(fmt.Errorf("received error: %s", res.Data.CustomerMessage), res)
-		}
-
 		return ListVersionsOutput{}, NewErrorWithMetadata(errors.New("invalid response"), res)
 	}
 

--- a/pkg/appstore/appstore_list_versions.go
+++ b/pkg/appstore/appstore_list_versions.go
@@ -33,6 +33,15 @@ func (t *appstore) ListVersions(input ListVersionsInput) (ListVersionsOutput, er
 		return ListVersionsOutput{}, fmt.Errorf("failed to send http request: %w", err)
 	}
 
+	if res.Data.FailureType == FailureTypeLicenseAlreadyExists {
+		req = t.redownloadRequest(input.Account, input.App, guid, "")
+
+		res, err = t.downloadClient.Send(req)
+		if err != nil {
+			return ListVersionsOutput{}, fmt.Errorf("failed to send http request: %w", err)
+		}
+	}
+
 	if res.Data.FailureType == FailureTypePasswordTokenExpired || res.Data.FailureType == FailureTypeSignInRequired {
 		return ListVersionsOutput{}, ErrPasswordTokenExpired
 	}
@@ -50,6 +59,10 @@ func (t *appstore) ListVersions(input ListVersionsInput) (ListVersionsOutput, er
 	}
 
 	if len(res.Data.Items) == 0 {
+		if res.Data.CustomerMessage != "" {
+			return ListVersionsOutput{}, NewErrorWithMetadata(fmt.Errorf("received error: %s", res.Data.CustomerMessage), res)
+		}
+
 		return ListVersionsOutput{}, NewErrorWithMetadata(errors.New("invalid response"), res)
 	}
 

--- a/pkg/appstore/appstore_list_versions_test.go
+++ b/pkg/appstore/appstore_list_versions_test.go
@@ -62,10 +62,10 @@ var _ = Describe("AppStore (ListVersions)", func() {
 		})
 	})
 
-	When("request uses a custom pod", func() {
+	When("request is sent", func() {
 		const (
-			testPod  = "42"
-			testGUID = "001122334455"
+			testEndpoint = "https://downloaddispatch.example.com/r/redownload"
+			testGUID     = "001122334455"
 		)
 
 		BeforeEach(func() {
@@ -76,18 +76,13 @@ var _ = Describe("AppStore (ListVersions)", func() {
 			mockDownloadClient.EXPECT().
 				Send(gomock.Any()).
 				Do(func(req http.Request) {
-					expectedURL := "https://p" + testPod + "-" + PrivateAppStoreAPIDomain + PrivateAppStoreAPIPathDownload + "?guid=" + testGUID
-					Expect(req.URL).To(Equal(expectedURL))
+					Expect(req.URL).To(Equal(testEndpoint + "?guid=" + testGUID))
 				}).
 				Return(http.Result[downloadResult]{}, errors.New(""))
 		})
 
-		It("sends the request to the pod-specific host", func() {
-			_, err := as.ListVersions(ListVersionsInput{
-				Account: Account{
-					Pod: testPod,
-				},
-			})
+		It("sends the request to the endpoint provided by the caller", func() {
+			_, err := as.ListVersions(ListVersionsInput{Endpoint: testEndpoint})
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/pkg/appstore/appstore_list_versions_test.go
+++ b/pkg/appstore/appstore_list_versions_test.go
@@ -277,6 +277,57 @@ var _ = Describe("AppStore (ListVersions)", func() {
 		})
 	})
 
+	When("primary endpoint returns FailureType 5002", func() {
+		const (
+			testVersion1 = "12345678"
+			testVersion2 = "87654321"
+			testLatest   = "87654321"
+		)
+
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:00:00:00:00:00", nil)
+
+			gomock.InOrder(
+				mockDownloadClient.EXPECT().
+					Send(gomock.Any()).
+					Do(func(req http.Request) {
+						Expect(req.URL).To(ContainSubstring(PrivateAppStoreAPIPathDownload))
+					}).
+					Return(http.Result[downloadResult]{
+						Data: downloadResult{
+							FailureType: FailureTypeLicenseAlreadyExists,
+						},
+					}, nil),
+				mockDownloadClient.EXPECT().
+					Send(gomock.Any()).
+					Do(func(req http.Request) {
+						Expect(req.URL).To(ContainSubstring(PrivateDownloadDispatchAPIDomain))
+					}).
+					Return(http.Result[downloadResult]{
+						Data: downloadResult{
+							Items: []downloadItemResult{
+								{
+									Metadata: map[string]interface{}{
+										"softwareVersionExternalIdentifiers": []interface{}{testVersion1, testVersion2},
+										"softwareVersionExternalIdentifier":  testLatest,
+									},
+								},
+							},
+						},
+					}, nil),
+			)
+		})
+
+		It("falls back to the redownload endpoint and returns versions", func() {
+			out, err := as.ListVersions(ListVersionsInput{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.ExternalVersionIdentifiers).To(Equal([]string{testVersion1, testVersion2}))
+			Expect(out.LatestExternalVersionID).To(Equal(testLatest))
+		})
+	})
+
 	When("successfully lists versions", func() {
 		const (
 			testVersion1 = "12345678"

--- a/pkg/appstore/appstore_list_versions_test.go
+++ b/pkg/appstore/appstore_list_versions_test.go
@@ -277,57 +277,6 @@ var _ = Describe("AppStore (ListVersions)", func() {
 		})
 	})
 
-	When("primary endpoint returns FailureType 5002", func() {
-		const (
-			testVersion1 = "12345678"
-			testVersion2 = "87654321"
-			testLatest   = "87654321"
-		)
-
-		BeforeEach(func() {
-			mockMachine.EXPECT().
-				MacAddress().
-				Return("00:00:00:00:00:00", nil)
-
-			gomock.InOrder(
-				mockDownloadClient.EXPECT().
-					Send(gomock.Any()).
-					Do(func(req http.Request) {
-						Expect(req.URL).To(ContainSubstring(PrivateAppStoreAPIPathDownload))
-					}).
-					Return(http.Result[downloadResult]{
-						Data: downloadResult{
-							FailureType: FailureTypeLicenseAlreadyExists,
-						},
-					}, nil),
-				mockDownloadClient.EXPECT().
-					Send(gomock.Any()).
-					Do(func(req http.Request) {
-						Expect(req.URL).To(ContainSubstring(PrivateDownloadDispatchAPIDomain))
-					}).
-					Return(http.Result[downloadResult]{
-						Data: downloadResult{
-							Items: []downloadItemResult{
-								{
-									Metadata: map[string]interface{}{
-										"softwareVersionExternalIdentifiers": []interface{}{testVersion1, testVersion2},
-										"softwareVersionExternalIdentifier":  testLatest,
-									},
-								},
-							},
-						},
-					}, nil),
-			)
-		})
-
-		It("falls back to the redownload endpoint and returns versions", func() {
-			out, err := as.ListVersions(ListVersionsInput{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(out.ExternalVersionIdentifiers).To(Equal([]string{testVersion1, testVersion2}))
-			Expect(out.LatestExternalVersionID).To(Equal(testLatest))
-		})
-	})
-
 	When("successfully lists versions", func() {
 		const (
 			testVersion1 = "12345678"

--- a/pkg/appstore/constants.go
+++ b/pkg/appstore/constants.go
@@ -25,9 +25,6 @@ const (
 	PrivateAppStoreAPIPathPurchase = "/WebObjects/MZFinance.woa/wa/buyProduct"
 	PrivateAppStoreAPIPathDownload = "/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct"
 
-	PrivateDownloadDispatchAPIDomain = "downloaddispatch." + iTunesAPIDomain
-	PrivateDownloadDispatchAPIPath   = "/r/redownload"
-
 	HTTPHeaderStoreFront = "X-Set-Apple-Store-Front"
 	HTTPHeaderPod        = "pod"
 

--- a/pkg/appstore/constants.go
+++ b/pkg/appstore/constants.go
@@ -25,6 +25,9 @@ const (
 	PrivateAppStoreAPIPathPurchase = "/WebObjects/MZFinance.woa/wa/buyProduct"
 	PrivateAppStoreAPIPathDownload = "/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct"
 
+	PrivateDownloadDispatchAPIDomain = "downloaddispatch." + iTunesAPIDomain
+	PrivateDownloadDispatchAPIPath   = "/r/redownload"
+
 	HTTPHeaderStoreFront = "X-Set-Apple-Store-Front"
 	HTTPHeaderPod        = "pod"
 

--- a/pkg/appstore/constants.go
+++ b/pkg/appstore/constants.go
@@ -23,7 +23,6 @@ const (
 
 	PrivateAppStoreAPIDomain       = "buy." + iTunesAPIDomain
 	PrivateAppStoreAPIPathPurchase = "/WebObjects/MZFinance.woa/wa/buyProduct"
-	PrivateAppStoreAPIPathDownload = "/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct"
 
 	HTTPHeaderStoreFront = "X-Set-Apple-Store-Front"
 	HTTPHeaderPod        = "pod"


### PR DESCRIPTION
Fixes #464.

## Problem

Apple's `volumeStoreDownloadProduct` endpoint returns `FailureType 5002` for consumer Apple IDs hitting apps with an existing license — Microsoft Teams, Office, Facebook, Spotify, and others — breaking `download`, `list-versions`, and `get-version-metadata`. That endpoint is Apple's VPP/ABM path; it just happened to accept some apps as a coincidence.

## Approach

Per @majd's feedback on the previous version of this PR:

> We should resolve this from the bag rather than hardcoding it here.

Apple's bag at `init.itunes.apple.com/bag.xml` already advertises a `redownloadProduct` key alongside the existing `authenticateAccount`. The URL is now resolved at runtime from the bag, not hardcoded anywhere.

## Changes

- **`BagOutput.DownloadEndpoint`** — `urlBag` parses the `redownloadProduct` key from the bag. Pure additive in its own commit; no caller consumes it yet.
- **`DownloadInput.Endpoint` / `ListVersionsInput.Endpoint` / `GetVersionMetadataInput.Endpoint`** — each `cmd/*` fetches the bag at the top of its retry function and threads the URL through, mirroring how `LoginInput.Endpoint` already works for `authenticateAccount`. The bag fetch that previously lived inside the token-expired retry branch is just promoted, so the same fetch serves both auth and download.
- **`appExtVrsId` payload key** — what the redownload endpoint expects for version pinning, replacing `externalVersionId`.
- **`PrivateAppStoreAPIPathDownload` removed** — no remaining references after the three call sites move to `bag.DownloadEndpoint`. Dead constants are slop.
- **`5002 → ErrPasswordTokenExpired` mapping in `Download` removed** — that mapping only existed to paper over the wrong endpoint; with the right endpoint, 5002 doesn't appear.

## Branch history

Rather than force-pushing the branch, the prior two commits (`47c7040`, `3aa4a86`) are kept reachable and explicitly reverted, so your earlier review comments stay anchored and accessible. The revert restores the tree to `main`; the six new commits build the bag-resolved approach on top. The branch can be merged as-is; the revert + new commits net out to the clean final diff.

Each commit builds and passes `go test ./...` independently.

## Verification

Against a real consumer Apple ID:

- `download com.microsoft.skype.teams` → 350 MB valid IPA, `Payload/TeamSpaceApp.app/` with code signature, plug-in extensions, and `TeamSpaceApp.sinf` intact.
- `list-versions com.microsoft.skype.teams` → full external version identifier list.
- `go test ./...` → green.

Same single-environment caveat as the original disclosure: Apple's responses on these endpoints aren't documented and vary by account state, storefront, family-sharing posture, and device-context fields. Other reporters confirming this fixes their 5002s on different apps would help validate generality.

## Failure mode worth flagging

There is no fallback to `volumeStoreDownloadProduct`. If Apple removes the `redownloadProduct` key from the bag, `bag.DownloadEndpoint` will be empty and the request will fail with a generic HTTP error. This is the same trust the existing code already places in the bag for `authenticateAccount` — keeping the old hardcoded URL as a fallback would reintroduce the exact 5002 bug this PR fixes. An explicit empty-string check at the call sites (clearer error message: "bag does not advertise a download endpoint") is a 3-line follow-up if you want it.

## Sources

- [#464](https://github.com/majd/ipatool/issues/464)
- Previous review feedback in this PR

---

Disclosure: code written by Claude Code; verified end-to-end against a live test account in one environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route App Store requests through the bag-resolved redownload endpoint to avoid `FailureType 5002`, restoring `download`, `list-versions`, and `get-version-metadata` for affected apps (fixes #464). Also fixes the interactive flag lookup so `auth login` and `download` interactive mode work again.

- **Bug Fixes**
  - Resolve `redownloadProduct` URL from the bag and pass it to `Download`, `ListVersions`, and `GetVersionMetadata`; use `appExtVrsId` for version pinning (`pkg/appstore` and `cmd/*`).
  - Remove `5002` → `ErrPasswordTokenExpired` mapping in `Download` to stop re-login loops.
  - When `Items` is empty, show `customerMessage` instead of “invalid response”.
  - Use typed `interactiveKey` in `cmd/auth.go` and `cmd/download.go` to prevent a panic and restore the progress bar.

<sup>Written for commit 032194273e86333322b56981f7adebbdd7b01ed3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

