### PR TITLE
Fix 429 rate limit handling and context key type mismatch in login #480

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -47,7 +47,7 @@ func loginCmd() *cobra.Command {
 		Use:   "login",
 		Short: "Login to the App Store",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			interactive := cmd.Context().Value("interactive").(bool)
+			interactive := cmd.Context().Value(interactiveKey).(bool)
 
 			if password == "" && !interactive {
 				return errors.New("password is required when not running in interactive mode; use the \"--password\" flag")

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -160,6 +160,10 @@ func (c *client[R]) handleXMLResponse(res *http.Response) (Result[R], error) {
 		return Result[R]{}, fmt.Errorf("failed to read response body: %w", err)
 	}
 
+	if res.StatusCode == http.StatusTooManyRequests {
+		return Result[R]{}, fmt.Errorf("rate limited by Apple (HTTP %d): %s", res.StatusCode, strings.TrimSpace(string(body)))
+	}
+
 	var data R
 
 	normalizedBody := normalizeXMLPlistBody(body)


### PR DESCRIPTION
This pull request introduces minor improvements for better code clarity and error handling. The most important changes are:

Error handling improvements:

* Added explicit handling for HTTP 429 (Too Many Requests) responses in `pkg/http/client.go`, returning a clear error message when rate limited by Apple.

Code clarity:

* Updated the `loginCmd` function in `cmd/auth.go` to use the `interactiveKey` constant for context value access, improving type safety and maintainability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit handling for HTTP 429 from Apple with a clear error, and uses `interactiveKey` with a strict bool assertion in login. Prevents confusing rate-limit failures and catches context type mismatches early.

<sup>Written for commit 7c8b158ae84914ca857a84484f54c13f83d43052. Summary will update on new commits. <a href="https://cubic.dev/pr/majd/ipatool/pull/481?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

