### PR TITLE
fix #464: fall back to the redownload endpoint when volumeStore returns 5002

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -43,12 +43,12 @@ func downloadCmd() *cobra.Command {
 
 				acc = infoResult.Account
 
-				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
-					bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
-					if err != nil {
-						return fmt.Errorf("failed to get bag: %w", err)
-					}
+				bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
+				if err != nil {
+					return fmt.Errorf("failed to get bag: %w", err)
+				}
 
+				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
 					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{
 						Email:    acc.Email,
 						Password: acc.Password,
@@ -111,12 +111,13 @@ func downloadCmd() *cobra.Command {
 				}
 
 				out, err := dependencies.AppStore.Download(appstore.DownloadInput{
-					Account:           acc,
-					App:               app,
-					OutputPath:        outputPath,
-					Progress:          progress,
-					ExternalVersionID: externalVersionID,
-					Platform:          platform,
+					Account:            acc,
+					App:                app,
+					OutputPath:         outputPath,
+					Progress:           progress,
+					ExternalVersionID:  externalVersionID,
+					Platform:           platform,
+					RedownloadEndpoint: bagOutput.RedownloadEndpoint,
 				})
 				if err != nil {
 					return err

--- a/cmd/get_version_metadata.go
+++ b/cmd/get_version_metadata.go
@@ -37,12 +37,12 @@ func getVersionMetadataCmd() *cobra.Command {
 
 				acc = infoResult.Account
 
-				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
-					bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
-					if err != nil {
-						return fmt.Errorf("failed to get bag: %w", err)
-					}
+				bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
+				if err != nil {
+					return fmt.Errorf("failed to get bag: %w", err)
+				}
 
+				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
 					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{
 						Email:    acc.Email,
 						Password: acc.Password,
@@ -66,9 +66,10 @@ func getVersionMetadataCmd() *cobra.Command {
 				}
 
 				out, err := dependencies.AppStore.GetVersionMetadata(appstore.GetVersionMetadataInput{
-					Account:   acc,
-					App:       app,
-					VersionID: externalVersionID,
+					Account:            acc,
+					App:                app,
+					VersionID:          externalVersionID,
+					RedownloadEndpoint: bagOutput.RedownloadEndpoint,
 				})
 				if err != nil {
 					return err

--- a/cmd/list_versions.go
+++ b/cmd/list_versions.go
@@ -36,12 +36,12 @@ func ListVersionsCmd() *cobra.Command {
 
 				acc = infoResult.Account
 
-				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
-					bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
-					if err != nil {
-						return fmt.Errorf("failed to get bag: %w", err)
-					}
+				bagOutput, err := dependencies.AppStore.Bag(appstore.BagInput{})
+				if err != nil {
+					return fmt.Errorf("failed to get bag: %w", err)
+				}
 
+				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
 					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{
 						Email:    acc.Email,
 						Password: acc.Password,
@@ -64,7 +64,11 @@ func ListVersionsCmd() *cobra.Command {
 					app = lookupResult.App
 				}
 
-				out, err := dependencies.AppStore.ListVersions(appstore.ListVersionsInput{Account: acc, App: app})
+				out, err := dependencies.AppStore.ListVersions(appstore.ListVersionsInput{
+					Account:            acc,
+					App:                app,
+					RedownloadEndpoint: bagOutput.RedownloadEndpoint,
+				})
 				if err != nil {
 					return err
 				}

--- a/pkg/appstore/appstore_bag.go
+++ b/pkg/appstore/appstore_bag.go
@@ -11,7 +11,8 @@ import (
 type BagInput struct{}
 
 type BagOutput struct {
-	AuthEndpoint string
+	AuthEndpoint       string
+	RedownloadEndpoint string
 }
 
 func (t *appstore) Bag(input BagInput) (BagOutput, error) {
@@ -33,7 +34,8 @@ func (t *appstore) Bag(input BagInput) (BagOutput, error) {
 	}
 
 	return BagOutput{
-		AuthEndpoint: res.Data.URLBag.AuthEndpoint,
+		AuthEndpoint:       res.Data.URLBag.AuthEndpoint,
+		RedownloadEndpoint: res.Data.URLBag.RedownloadEndpoint,
 	}, nil
 }
 
@@ -42,7 +44,8 @@ type bagResult struct {
 }
 
 type urlBag struct {
-	AuthEndpoint string `plist:"authenticateAccount,omitempty"`
+	AuthEndpoint       string `plist:"authenticateAccount,omitempty"`
+	RedownloadEndpoint string `plist:"redownloadProduct,omitempty"`
 }
 
 func (*appstore) bagRequest(guid string) http.Request {

--- a/pkg/appstore/appstore_bag_test.go
+++ b/pkg/appstore/appstore_bag_test.go
@@ -86,7 +86,10 @@ var _ = Describe("AppStore (Bag)", func() {
 	})
 
 	When("request is successful with authenticateAccount in urlBag", func() {
-		const testAuthEndpoint = "https://example.com"
+		const (
+			testAuthEndpoint       = "https://example.com"
+			testRedownloadEndpoint = "https://downloaddispatch.itunes.apple.com/r/redownload"
+		)
 
 		BeforeEach(func() {
 			mockMachine.EXPECT().
@@ -105,7 +108,8 @@ var _ = Describe("AppStore (Bag)", func() {
 					StatusCode: gohttp.StatusOK,
 					Data: bagResult{
 						URLBag: urlBag{
-							AuthEndpoint: testAuthEndpoint,
+							AuthEndpoint:       testAuthEndpoint,
+							RedownloadEndpoint: testRedownloadEndpoint,
 						},
 					},
 				}, nil)
@@ -115,6 +119,7 @@ var _ = Describe("AppStore (Bag)", func() {
 			out, err := as.Bag(BagInput{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out.AuthEndpoint).To(Equal(testAuthEndpoint))
+			Expect(out.RedownloadEndpoint).To(Equal(testRedownloadEndpoint))
 		})
 	})
 

--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/majd/ipatool/v2/pkg/http"
 	"github.com/schollz/progressbar/v3"
 	"howett.net/plist"
 )
@@ -19,12 +18,13 @@ var (
 )
 
 type DownloadInput struct {
-	Account           Account
-	App               App
-	OutputPath        string
-	Progress          *progressbar.ProgressBar
-	ExternalVersionID string
-	Platform          Platform
+	Account            Account
+	App                App
+	OutputPath         string
+	Progress           *progressbar.ProgressBar
+	ExternalVersionID  string
+	Platform           Platform
+	RedownloadEndpoint string
 }
 
 type DownloadOutput struct {
@@ -48,37 +48,15 @@ func (t *appstore) Download(input DownloadInput) (DownloadOutput, error) {
 		}
 	}
 
-	req := t.downloadRequest(input.Account, input.App, guid, externalVersionID)
-
-	res, err := t.downloadClient.Send(req)
+	res, err := t.sendDownloadProduct(input.Account, input.App, guid, externalVersionID, input.RedownloadEndpoint)
 	if err != nil {
-		return DownloadOutput{}, fmt.Errorf("failed to send http request: %w", err)
+		return DownloadOutput{}, err
 	}
 
-	if res.Data.FailureType == FailureTypePasswordTokenExpired ||
-		res.Data.FailureType == FailureTypeSignInRequired ||
-		res.Data.FailureType == FailureTypeDeviceVerificationFailed ||
-		res.Data.FailureType == FailureTypeLicenseAlreadyExists {
-		return DownloadOutput{}, ErrPasswordTokenExpired
+	item, err := downloadProductItem(res)
+	if err != nil {
+		return DownloadOutput{}, err
 	}
-
-	if res.Data.FailureType == FailureTypeLicenseNotFound {
-		return DownloadOutput{}, ErrLicenseRequired
-	}
-
-	if res.Data.FailureType != "" && res.Data.CustomerMessage != "" {
-		return DownloadOutput{}, NewErrorWithMetadata(fmt.Errorf("received error: %s", res.Data.CustomerMessage), res)
-	}
-
-	if res.Data.FailureType != "" {
-		return DownloadOutput{}, NewErrorWithMetadata(fmt.Errorf("received error: %s", res.Data.FailureType), res)
-	}
-
-	if len(res.Data.Items) == 0 {
-		return DownloadOutput{}, NewErrorWithMetadata(errors.New("invalid response"), res)
-	}
-
-	item := res.Data.Items[0]
 
 	version := "unknown"
 
@@ -237,37 +215,6 @@ func (t *appstore) downloadFile(src, dst string, progress *progressbar.ProgressB
 	}
 
 	return nil
-}
-
-func (*appstore) downloadRequest(acc Account, app App, guid string, externalVersionID string) http.Request {
-	payload := map[string]interface{}{
-		"creditDisplay": "",
-		"guid":          guid,
-		"salableAdamId": app.ID,
-	}
-
-	if externalVersionID != "" {
-		payload["externalVersionId"] = externalVersionID
-	}
-
-	podPrefix := ""
-	if acc.Pod != "" {
-		podPrefix = "p" + acc.Pod + "-"
-	}
-
-	return http.Request{
-		URL:            fmt.Sprintf("https://%s%s%s?guid=%s", podPrefix, PrivateAppStoreAPIDomain, PrivateAppStoreAPIPathDownload, guid),
-		Method:         http.MethodPOST,
-		ResponseFormat: http.ResponseFormatXML,
-		Headers: map[string]string{
-			"Content-Type": "application/x-apple-plist",
-			"iCloud-DSID":  acc.DirectoryServicesID,
-			"X-Dsid":       acc.DirectoryServicesID,
-		},
-		Payload: &http.XMLPayload{
-			Content: payload,
-		},
-	}
 }
 
 func fileName(app App, version string) string {

--- a/pkg/appstore/appstore_download_test.go
+++ b/pkg/appstore/appstore_download_test.go
@@ -187,6 +187,62 @@ var _ = Describe("AppStore (Download)", func() {
 		})
 	})
 
+	When("a licensed tvOS app falls back to the redownload endpoint", func() {
+		const testRedownload = "https://downloaddispatch.itunes.apple.com/r/redownload"
+
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			mockPlatformClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[platformVersionLookupResult]{
+					StatusCode: 200,
+					Data: platformVersionLookupResult{
+						Results: map[string]platformVersionLookupItem{
+							"42": {
+								Offers: []platformVersionLookupOffer{
+									{Version: platformVersionLookupVersion{ExternalID: platformVersionExternalID("123456")}},
+								},
+							},
+						},
+					},
+				}, nil)
+
+			gomock.InOrder(
+				mockDownloadClient.EXPECT().
+					Send(gomock.Any()).
+					Do(func(req http.Request) {
+						Expect(req.URL).To(ContainSubstring(PrivateAppStoreAPIPathDownload))
+						payload := req.Payload.(*http.XMLPayload)
+						Expect(payload.Content).To(HaveKeyWithValue(downloadVersionKeyVolumeStore, "123456"))
+						Expect(payload.Content).ToNot(HaveKey(downloadVersionKeyRedownload))
+					}).
+					Return(http.Result[downloadResult]{Data: downloadResult{FailureType: FailureTypeLicenseAlreadyExists}}, nil),
+				mockDownloadClient.EXPECT().
+					Send(gomock.Any()).
+					Do(func(req http.Request) {
+						Expect(req.URL).To(HavePrefix(testRedownload))
+						payload := req.Payload.(*http.XMLPayload)
+						Expect(payload.Content).To(HaveKeyWithValue(downloadVersionKeyRedownload, "123456"))
+						Expect(payload.Content).ToNot(HaveKey(downloadVersionKeyVolumeStore))
+					}).
+					Return(http.Result[downloadResult]{}, errors.New("stop after fallback")),
+			)
+		})
+
+		It("retries on redownload translating externalVersionId to appExtVrsId", func() {
+			_, err := as.Download(DownloadInput{
+				Account:            Account{StoreFront: "143441"},
+				App:                App{ID: 42},
+				Platform:           PlatformAppleTV,
+				RedownloadEndpoint: testRedownload,
+			})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	DescribeTable("platform uses the standard download request",
 		func(platform Platform) {
 			mockMachine.EXPECT().

--- a/pkg/appstore/appstore_endpoint.go
+++ b/pkg/appstore/appstore_endpoint.go
@@ -1,0 +1,180 @@
+package appstore
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/majd/ipatool/v2/pkg/http"
+)
+
+// The App Store exposes two interchangeable download endpoints that, for a
+// consumer Apple ID, serve disjoint sets of apps (issue #464):
+//
+//   - volumeStore (buy.itunes.apple.com/.../volumeStoreDownloadProduct) serves
+//     apps the account holds no consumer license for. For apps it does hold a
+//     license for it returns failureType 5002 (FailureTypeLicenseAlreadyExists).
+//   - redownload (advertised by the bag as redownloadProduct) serves the
+//     licensed apps. For everything else it returns an empty failureType with a
+//     "<App> No Longer Available" customerMessage.
+//
+// volumeStore also returns 5002 *intermittently* for apps it can otherwise serve
+// (observed ~1 in 8 calls, typically the first), so a 5002 is not on its own
+// proof that an app is licensed. The redownload response disambiguates: if
+// redownload serves the app it was genuinely licensed; if redownload cannot
+// serve it either, the 5002 was transient and volumeStore is retried.
+//
+// The two endpoints also disagree on the key used to pin an external version:
+// volumeStore reads externalVersionId, redownload reads appExtVrsId. The unused
+// key is silently ignored, so the request must carry the right one.
+const (
+	downloadVersionKeyVolumeStore = "externalVersionId"
+	downloadVersionKeyRedownload  = "appExtVrsId"
+
+	// volumeStoreRetriesAfterFallback is how many extra times volumeStore is
+	// tried when it returned 5002 but redownload also could not serve the app —
+	// i.e. when the 5002 was a transient hiccup rather than a real license.
+	volumeStoreRetriesAfterFallback = 2
+)
+
+// downloadProductEndpoint identifies a download endpoint and the version-pin key
+// it expects.
+type downloadProductEndpoint struct {
+	baseURL    string
+	versionKey string
+}
+
+// volumeStoreEndpoint is the primary endpoint. It is not resolved from the bag:
+// the bag advertises a volumeStoreDownloadProduct URL, but that host speaks the
+// enterprise/VPP protocol and rejects ipatool's request shape, so the long-lived
+// MZFinance URL is used directly.
+func (*appstore) volumeStoreEndpoint(acc Account) downloadProductEndpoint {
+	podPrefix := ""
+	if acc.Pod != "" {
+		podPrefix = "p" + acc.Pod + "-"
+	}
+
+	return downloadProductEndpoint{
+		baseURL:    fmt.Sprintf("https://%s%s%s", podPrefix, PrivateAppStoreAPIDomain, PrivateAppStoreAPIPathDownload),
+		versionKey: downloadVersionKeyVolumeStore,
+	}
+}
+
+// redownloadEndpoint is the fallback endpoint, resolved from the bag.
+func redownloadEndpoint(bagURL string) downloadProductEndpoint {
+	return downloadProductEndpoint{
+		baseURL:    bagURL,
+		versionKey: downloadVersionKeyRedownload,
+	}
+}
+
+func (*appstore) downloadProductRequest(endpoint downloadProductEndpoint, acc Account, app App, guid, externalVersionID string) http.Request {
+	payload := map[string]interface{}{
+		"creditDisplay": "",
+		"guid":          guid,
+		"salableAdamId": app.ID,
+	}
+
+	if externalVersionID != "" {
+		payload[endpoint.versionKey] = externalVersionID
+	}
+
+	return http.Request{
+		URL:            fmt.Sprintf("%s?guid=%s", endpoint.baseURL, guid),
+		Method:         http.MethodPOST,
+		ResponseFormat: http.ResponseFormatXML,
+		Headers: map[string]string{
+			"Content-Type": "application/x-apple-plist",
+			"iCloud-DSID":  acc.DirectoryServicesID,
+			"X-Dsid":       acc.DirectoryServicesID,
+		},
+		Payload: &http.XMLPayload{
+			Content: payload,
+		},
+	}
+}
+
+// sendDownloadProduct sends a download-family request to the primary volumeStore
+// endpoint, resolving issue #464 with a fallback to the bag-advertised redownload
+// endpoint. redownloadBagURL is the bag's redownloadProduct URL; when it is empty
+// (a bag that does not advertise the key) only the primary endpoint is used.
+//
+// On a volumeStore 5002 it tries redownload. If redownload serves the app, that
+// response is used (the app was genuinely licensed). If redownload cannot serve
+// it either — an empty failureType with no items, the "No Longer Available"
+// signature — the 5002 was transient, so volumeStore is retried.
+func (t *appstore) sendDownloadProduct(acc Account, app App, guid, externalVersionID, redownloadBagURL string) (http.Result[downloadResult], error) {
+	volumeStore := t.volumeStoreEndpoint(acc)
+
+	res, err := t.downloadClient.Send(t.downloadProductRequest(volumeStore, acc, app, guid, externalVersionID))
+	if err != nil {
+		return res, fmt.Errorf("failed to send http request: %w", err)
+	}
+
+	if res.Data.FailureType != FailureTypeLicenseAlreadyExists || redownloadBagURL == "" {
+		return res, nil
+	}
+
+	redownloadRes, err := t.downloadClient.Send(t.downloadProductRequest(redownloadEndpoint(redownloadBagURL), acc, app, guid, externalVersionID))
+	if err != nil {
+		return redownloadRes, fmt.Errorf("failed to send http request: %w", err)
+	}
+
+	// Redownload served the app (genuinely licensed, e.g. Microsoft Teams) or
+	// returned an actionable failure (auth/license) — use that response.
+	if len(redownloadRes.Data.Items) > 0 || redownloadRes.Data.FailureType != "" {
+		return redownloadRes, nil
+	}
+
+	// Redownload cannot serve the app, so the volumeStore 5002 was a transient
+	// hiccup rather than a real license. Retry volumeStore.
+	for i := 0; i < volumeStoreRetriesAfterFallback; i++ {
+		res, err = t.downloadClient.Send(t.downloadProductRequest(volumeStore, acc, app, guid, externalVersionID))
+		if err != nil {
+			return res, fmt.Errorf("failed to send http request: %w", err)
+		}
+
+		if res.Data.FailureType != FailureTypeLicenseAlreadyExists {
+			return res, nil
+		}
+	}
+
+	// volumeStore kept returning 5002 and redownload cannot serve the app; the
+	// redownload response carries the most informative message for the caller.
+	return redownloadRes, nil
+}
+
+// downloadProductItem interprets a download-family response, returning the first
+// song-list item or a typed error. It is shared by Download, ListVersions and
+// GetVersionMetadata, which all POST the same payload and decode the same shape.
+func downloadProductItem(res http.Result[downloadResult]) (downloadItemResult, error) {
+	switch {
+	case res.Data.FailureType == FailureTypePasswordTokenExpired ||
+		res.Data.FailureType == FailureTypeSignInRequired ||
+		res.Data.FailureType == FailureTypeDeviceVerificationFailed:
+		return downloadItemResult{}, ErrPasswordTokenExpired
+	case res.Data.FailureType == FailureTypeLicenseNotFound:
+		return downloadItemResult{}, ErrLicenseRequired
+	case res.Data.FailureType == FailureTypeLicenseAlreadyExists:
+		// 5002 means the account already holds a consumer license, so the app
+		// can only be fetched from the redownload endpoint. Reaching here means
+		// the fallback was unavailable — the bag advertised no redownloadProduct
+		// URL. Surface that plainly instead of the endpoint's opaque "An unknown
+		// error has occurred" customerMessage.
+		return downloadItemResult{}, NewErrorWithMetadata(errors.New("the App Store requires the redownload endpoint for this app (failureType 5002), but the bag did not advertise one"), res)
+	case res.Data.FailureType != "" && res.Data.CustomerMessage != "":
+		return downloadItemResult{}, NewErrorWithMetadata(fmt.Errorf("received error: %s", res.Data.CustomerMessage), res)
+	case res.Data.FailureType != "":
+		return downloadItemResult{}, NewErrorWithMetadata(fmt.Errorf("received error: %s", res.Data.FailureType), res)
+	case len(res.Data.Items) == 0:
+		// The redownload endpoint reports apps it cannot serve with an empty
+		// failureType and a "<App> No Longer Available" customerMessage; surface
+		// that rather than a generic "invalid response".
+		if res.Data.CustomerMessage != "" {
+			return downloadItemResult{}, NewErrorWithMetadata(fmt.Errorf("received error: %s", res.Data.CustomerMessage), res)
+		}
+
+		return downloadItemResult{}, NewErrorWithMetadata(errors.New("invalid response"), res)
+	default:
+		return res.Data.Items[0], nil
+	}
+}

--- a/pkg/appstore/appstore_endpoint_test.go
+++ b/pkg/appstore/appstore_endpoint_test.go
@@ -1,0 +1,189 @@
+package appstore
+
+import (
+	"errors"
+
+	"github.com/majd/ipatool/v2/pkg/http"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+)
+
+var _ = Describe("AppStore (download endpoint fallback)", func() {
+	const redownloadURL = "https://downloaddispatch.itunes.apple.com/r/redownload"
+
+	var (
+		ctrl               *gomock.Controller
+		mockDownloadClient *http.MockClient[downloadResult]
+		st                 *appstore
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockDownloadClient = http.NewMockClient[downloadResult](ctrl)
+		st = &appstore{downloadClient: mockDownloadClient}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	failure := func(ft string) http.Result[downloadResult] {
+		return http.Result[downloadResult]{Data: downloadResult{FailureType: ft}}
+	}
+	success := func() http.Result[downloadResult] {
+		return http.Result[downloadResult]{Data: downloadResult{Items: []downloadItemResult{{URL: "https://example.com/app.ipa"}}}}
+	}
+	noLongerAvailable := func() http.Result[downloadResult] {
+		return http.Result[downloadResult]{Data: downloadResult{CustomerMessage: "“App” No Longer Available"}}
+	}
+
+	Describe("sendDownloadProduct", func() {
+		When("the volumeStore endpoint returns failureType 5002 and a redownload endpoint is available", func() {
+			It("retries on the redownload endpoint with the appExtVrsId version key", func() {
+				gomock.InOrder(
+					mockDownloadClient.EXPECT().
+						Send(gomock.Any()).
+						Do(func(req http.Request) {
+							Expect(req.URL).To(ContainSubstring(PrivateAppStoreAPIPathDownload))
+							payload := req.Payload.(*http.XMLPayload)
+							Expect(payload.Content).To(HaveKeyWithValue(downloadVersionKeyVolumeStore, "123"))
+							Expect(payload.Content).ToNot(HaveKey(downloadVersionKeyRedownload))
+						}).
+						Return(failure(FailureTypeLicenseAlreadyExists), nil),
+					mockDownloadClient.EXPECT().
+						Send(gomock.Any()).
+						Do(func(req http.Request) {
+							Expect(req.URL).To(HavePrefix(redownloadURL))
+							payload := req.Payload.(*http.XMLPayload)
+							Expect(payload.Content).To(HaveKeyWithValue(downloadVersionKeyRedownload, "123"))
+							Expect(payload.Content).ToNot(HaveKey(downloadVersionKeyVolumeStore))
+						}).
+						Return(success(), nil),
+				)
+
+				res, err := st.sendDownloadProduct(Account{}, App{ID: 42}, "GUID", "123", redownloadURL)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.Data.Items).To(HaveLen(1))
+			})
+		})
+
+		When("the volumeStore endpoint returns 5002 but no redownload endpoint is configured", func() {
+			It("does not retry and returns the original response", func() {
+				mockDownloadClient.EXPECT().
+					Send(gomock.Any()).
+					Return(failure(FailureTypeLicenseAlreadyExists), nil).
+					Times(1)
+
+				res, err := st.sendDownloadProduct(Account{}, App{ID: 42}, "GUID", "", "")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.Data.FailureType).To(Equal(FailureTypeLicenseAlreadyExists))
+			})
+		})
+
+		When("volumeStore returns a transient 5002 that redownload cannot serve", func() {
+			It("retries volumeStore and uses its recovered response", func() {
+				gomock.InOrder(
+					mockDownloadClient.EXPECT().
+						Send(gomock.Any()).
+						Do(func(req http.Request) { Expect(req.URL).To(ContainSubstring(PrivateAppStoreAPIPathDownload)) }).
+						Return(failure(FailureTypeLicenseAlreadyExists), nil),
+					mockDownloadClient.EXPECT().
+						Send(gomock.Any()).
+						Do(func(req http.Request) { Expect(req.URL).To(HavePrefix(redownloadURL)) }).
+						Return(noLongerAvailable(), nil),
+					mockDownloadClient.EXPECT().
+						Send(gomock.Any()).
+						Do(func(req http.Request) { Expect(req.URL).To(ContainSubstring(PrivateAppStoreAPIPathDownload)) }).
+						Return(success(), nil),
+				)
+
+				res, err := st.sendDownloadProduct(Account{}, App{ID: 42}, "GUID", "", redownloadURL)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.Data.Items).To(HaveLen(1))
+			})
+		})
+
+		When("volumeStore keeps returning 5002 and redownload cannot serve the app", func() {
+			It("returns the redownload response so the caller sees the informative message", func() {
+				gomock.InOrder(
+					mockDownloadClient.EXPECT().Send(gomock.Any()).Return(failure(FailureTypeLicenseAlreadyExists), nil),
+					mockDownloadClient.EXPECT().Send(gomock.Any()).Return(noLongerAvailable(), nil),
+					mockDownloadClient.EXPECT().Send(gomock.Any()).Return(failure(FailureTypeLicenseAlreadyExists), nil).Times(volumeStoreRetriesAfterFallback),
+				)
+
+				res, err := st.sendDownloadProduct(Account{}, App{ID: 42}, "GUID", "", redownloadURL)
+				Expect(err).ToNot(HaveOccurred())
+				_, itemErr := downloadProductItem(res)
+				Expect(itemErr.Error()).To(ContainSubstring("No Longer Available"))
+			})
+		})
+
+		When("the volumeStore endpoint succeeds", func() {
+			It("does not call the redownload endpoint", func() {
+				mockDownloadClient.EXPECT().
+					Send(gomock.Any()).
+					Return(success(), nil).
+					Times(1)
+
+				res, err := st.sendDownloadProduct(Account{}, App{ID: 42}, "GUID", "", redownloadURL)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.Data.Items).To(HaveLen(1))
+			})
+		})
+
+		When("the volumeStore endpoint returns a non-5002 failure", func() {
+			It("does not fall back", func() {
+				mockDownloadClient.EXPECT().
+					Send(gomock.Any()).
+					Return(failure(FailureTypeLicenseNotFound), nil).
+					Times(1)
+
+				res, err := st.sendDownloadProduct(Account{}, App{ID: 42}, "GUID", "", redownloadURL)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.Data.FailureType).To(Equal(FailureTypeLicenseNotFound))
+			})
+		})
+	})
+
+	Describe("downloadProductItem", func() {
+		It("reports a clear error for a surviving 5002 (no redownload endpoint available)", func() {
+			_, err := downloadProductItem(http.Result[downloadResult]{Data: downloadResult{
+				FailureType:     FailureTypeLicenseAlreadyExists,
+				CustomerMessage: "An unknown error has occurred",
+			}})
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ErrPasswordTokenExpired)).To(BeFalse())
+			Expect(err.Error()).To(ContainSubstring("redownload endpoint"))
+			Expect(err.Error()).ToNot(ContainSubstring("An unknown error has occurred"))
+		})
+
+		It("surfaces the customerMessage when the redownload endpoint reports the app unavailable", func() {
+			res := http.Result[downloadResult]{Data: downloadResult{CustomerMessage: "“YouTube” No Longer Available"}}
+			_, err := downloadProductItem(res)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("No Longer Available"))
+		})
+
+		It("maps password-token-expired failures to ErrPasswordTokenExpired", func() {
+			_, err := downloadProductItem(failure(FailureTypePasswordTokenExpired))
+			Expect(errors.Is(err, ErrPasswordTokenExpired)).To(BeTrue())
+		})
+
+		It("maps sign-in-required failures to ErrPasswordTokenExpired", func() {
+			_, err := downloadProductItem(failure(FailureTypeSignInRequired))
+			Expect(errors.Is(err, ErrPasswordTokenExpired)).To(BeTrue())
+		})
+
+		It("maps license-not-found failures to ErrLicenseRequired", func() {
+			_, err := downloadProductItem(failure(FailureTypeLicenseNotFound))
+			Expect(errors.Is(err, ErrLicenseRequired)).To(BeTrue())
+		})
+
+		It("returns the first song-list item on success", func() {
+			item, err := downloadProductItem(success())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(item.URL).To(Equal("https://example.com/app.ipa"))
+		})
+	})
+})

--- a/pkg/appstore/appstore_get_version_metadata.go
+++ b/pkg/appstore/appstore_get_version_metadata.go
@@ -1,18 +1,16 @@
 package appstore
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/majd/ipatool/v2/pkg/http"
 )
 
 type GetVersionMetadataInput struct {
-	Account   Account
-	App       App
-	VersionID string
+	Account            Account
+	App                App
+	VersionID          string
+	RedownloadEndpoint string
 }
 
 type GetVersionMetadataOutput struct {
@@ -28,34 +26,15 @@ func (t *appstore) GetVersionMetadata(input GetVersionMetadataInput) (GetVersion
 
 	guid := strings.ReplaceAll(strings.ToUpper(macAddr), ":", "")
 
-	req := t.getVersionMetadataRequest(input.Account, input.App, guid, input.VersionID)
-	res, err := t.downloadClient.Send(req)
-
+	res, err := t.sendDownloadProduct(input.Account, input.App, guid, input.VersionID, input.RedownloadEndpoint)
 	if err != nil {
-		return GetVersionMetadataOutput{}, fmt.Errorf("failed to send http request: %w", err)
+		return GetVersionMetadataOutput{}, err
 	}
 
-	if res.Data.FailureType == FailureTypePasswordTokenExpired || res.Data.FailureType == FailureTypeSignInRequired {
-		return GetVersionMetadataOutput{}, ErrPasswordTokenExpired
+	item, err := downloadProductItem(res)
+	if err != nil {
+		return GetVersionMetadataOutput{}, err
 	}
-
-	if res.Data.FailureType == FailureTypeLicenseNotFound {
-		return GetVersionMetadataOutput{}, ErrLicenseRequired
-	}
-
-	if res.Data.FailureType != "" && res.Data.CustomerMessage != "" {
-		return GetVersionMetadataOutput{}, NewErrorWithMetadata(fmt.Errorf("received error: %s", res.Data.CustomerMessage), res)
-	}
-
-	if res.Data.FailureType != "" {
-		return GetVersionMetadataOutput{}, NewErrorWithMetadata(fmt.Errorf("received error: %s", res.Data.FailureType), res)
-	}
-
-	if len(res.Data.Items) == 0 {
-		return GetVersionMetadataOutput{}, NewErrorWithMetadata(errors.New("invalid response"), res)
-	}
-
-	item := res.Data.Items[0]
 
 	// Do not fall back to item.Metadata here. The App Store download API can
 	// return stale version and release date values, so the IPA Info.plist is the
@@ -66,32 +45,4 @@ func (t *appstore) GetVersionMetadata(input GetVersionMetadataInput) (GetVersion
 	}
 
 	return GetVersionMetadataOutput(metadata), nil
-}
-
-func (t *appstore) getVersionMetadataRequest(acc Account, app App, guid string, version string) http.Request {
-	payload := map[string]interface{}{
-		"creditDisplay":     "",
-		"guid":              guid,
-		"salableAdamId":     app.ID,
-		"externalVersionId": version,
-	}
-
-	podPrefix := ""
-	if acc.Pod != "" {
-		podPrefix = "p" + acc.Pod + "-"
-	}
-
-	return http.Request{
-		URL:            fmt.Sprintf("https://%s%s%s?guid=%s", podPrefix, PrivateAppStoreAPIDomain, PrivateAppStoreAPIPathDownload, guid),
-		Method:         http.MethodPOST,
-		ResponseFormat: http.ResponseFormatXML,
-		Headers: map[string]string{
-			"Content-Type": "application/x-apple-plist",
-			"iCloud-DSID":  acc.DirectoryServicesID,
-			"X-Dsid":       acc.DirectoryServicesID,
-		},
-		Payload: &http.XMLPayload{
-			Content: payload,
-		},
-	}
 }

--- a/pkg/appstore/appstore_get_version_metadata_test.go
+++ b/pkg/appstore/appstore_get_version_metadata_test.go
@@ -521,4 +521,71 @@ var _ = Describe("AppStore (GetVersionMetadata)", func() {
 			Expect(atomic.LoadInt64(servedBytes)).To(BeNumerically("<", int64(len(ipa)/2)))
 		})
 	})
+
+	When("the volumeStore endpoint returns 5002 and a redownload endpoint is available", func() {
+		const testRedownload = "https://downloaddispatch.itunes.apple.com/r/redownload"
+
+		var (
+			server         *httptest.Server
+			releaseDate    time.Time
+			displayVersion string
+		)
+
+		BeforeEach(func() {
+			releaseDate = time.Date(2024, 4, 2, 12, 0, 0, 0, time.UTC)
+			displayVersion = "2.0.0"
+			ipa := testIPA(displayVersion, releaseDate.Format(time.RFC3339), time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+			server, _, _ = testIPAServer(ipa)
+
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			gomock.InOrder(
+				mockDownloadClient.EXPECT().
+					Send(gomock.Any()).
+					Do(func(req http.Request) {
+						Expect(req.URL).To(ContainSubstring(PrivateAppStoreAPIPathDownload))
+						payload := req.Payload.(*http.XMLPayload)
+						Expect(payload.Content).To(HaveKeyWithValue(downloadVersionKeyVolumeStore, "test-version"))
+					}).
+					Return(http.Result[downloadResult]{Data: downloadResult{FailureType: FailureTypeLicenseAlreadyExists}}, nil),
+				mockDownloadClient.EXPECT().
+					Send(gomock.Any()).
+					Do(func(req http.Request) {
+						Expect(req.URL).To(HavePrefix(testRedownload))
+						payload := req.Payload.(*http.XMLPayload)
+						Expect(payload.Content).To(HaveKeyWithValue(downloadVersionKeyRedownload, "test-version"))
+					}).
+					Return(http.Result[downloadResult]{
+						Data: downloadResult{
+							Items: []downloadItemResult{
+								{
+									URL: server.URL,
+									Metadata: map[string]interface{}{
+										"releaseDate":              "2020-01-01T00:00:00Z",
+										"bundleShortVersionString": "1.0.0",
+									},
+								},
+							},
+						},
+					}, nil),
+			)
+		})
+
+		AfterEach(func() {
+			server.Close()
+		})
+
+		It("falls back to the redownload endpoint and returns metadata", func() {
+			output, err := as.GetVersionMetadata(GetVersionMetadataInput{
+				App:                App{ID: 1234567890},
+				VersionID:          "test-version",
+				RedownloadEndpoint: testRedownload,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output.DisplayVersion).To(Equal(displayVersion))
+			Expect(output.ReleaseDate).To(Equal(releaseDate))
+		})
+	})
 })

--- a/pkg/appstore/appstore_list_versions.go
+++ b/pkg/appstore/appstore_list_versions.go
@@ -1,16 +1,14 @@
 package appstore
 
 import (
-	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/majd/ipatool/v2/pkg/http"
 )
 
 type ListVersionsInput struct {
-	Account Account
-	App     App
+	Account            Account
+	App                App
+	RedownloadEndpoint string
 }
 
 type ListVersionsOutput struct {
@@ -26,34 +24,15 @@ func (t *appstore) ListVersions(input ListVersionsInput) (ListVersionsOutput, er
 
 	guid := strings.ReplaceAll(strings.ToUpper(macAddr), ":", "")
 
-	req := t.listVersionsRequest(input.Account, input.App, guid)
-	res, err := t.downloadClient.Send(req)
-
+	res, err := t.sendDownloadProduct(input.Account, input.App, guid, "", input.RedownloadEndpoint)
 	if err != nil {
-		return ListVersionsOutput{}, fmt.Errorf("failed to send http request: %w", err)
+		return ListVersionsOutput{}, err
 	}
 
-	if res.Data.FailureType == FailureTypePasswordTokenExpired || res.Data.FailureType == FailureTypeSignInRequired {
-		return ListVersionsOutput{}, ErrPasswordTokenExpired
+	item, err := downloadProductItem(res)
+	if err != nil {
+		return ListVersionsOutput{}, err
 	}
-
-	if res.Data.FailureType == FailureTypeLicenseNotFound {
-		return ListVersionsOutput{}, ErrLicenseRequired
-	}
-
-	if res.Data.FailureType != "" && res.Data.CustomerMessage != "" {
-		return ListVersionsOutput{}, NewErrorWithMetadata(fmt.Errorf("received error: %s", res.Data.CustomerMessage), res)
-	}
-
-	if res.Data.FailureType != "" {
-		return ListVersionsOutput{}, NewErrorWithMetadata(fmt.Errorf("received error: %s", res.Data.FailureType), res)
-	}
-
-	if len(res.Data.Items) == 0 {
-		return ListVersionsOutput{}, NewErrorWithMetadata(errors.New("invalid response"), res)
-	}
-
-	item := res.Data.Items[0]
 
 	rawIdentifiers, ok := item.Metadata["softwareVersionExternalIdentifiers"].([]interface{})
 	if !ok {
@@ -74,31 +53,4 @@ func (t *appstore) ListVersions(input ListVersionsInput) (ListVersionsOutput, er
 		ExternalVersionIdentifiers: externalVersionIdentifiers,
 		LatestExternalVersionID:    fmt.Sprintf("%v", latestExternalVersionID),
 	}, nil
-}
-
-func (t *appstore) listVersionsRequest(acc Account, app App, guid string) http.Request {
-	payload := map[string]interface{}{
-		"creditDisplay": "",
-		"guid":          guid,
-		"salableAdamId": app.ID,
-	}
-
-	podPrefix := ""
-	if acc.Pod != "" {
-		podPrefix = "p" + acc.Pod + "-"
-	}
-
-	return http.Request{
-		URL:            fmt.Sprintf("https://%s%s%s?guid=%s", podPrefix, PrivateAppStoreAPIDomain, PrivateAppStoreAPIPathDownload, guid),
-		Method:         http.MethodPOST,
-		ResponseFormat: http.ResponseFormatXML,
-		Headers: map[string]string{
-			"Content-Type": "application/x-apple-plist",
-			"iCloud-DSID":  acc.DirectoryServicesID,
-			"X-Dsid":       acc.DirectoryServicesID,
-		},
-		Payload: &http.XMLPayload{
-			Content: payload,
-		},
-	}
 }

--- a/pkg/appstore/appstore_list_versions_test.go
+++ b/pkg/appstore/appstore_list_versions_test.go
@@ -312,4 +312,49 @@ var _ = Describe("AppStore (ListVersions)", func() {
 			Expect(out.LatestExternalVersionID).To(Equal(testLatest))
 		})
 	})
+
+	When("the volumeStore endpoint returns 5002 and a redownload endpoint is available", func() {
+		const (
+			testRedownload = "https://downloaddispatch.itunes.apple.com/r/redownload"
+			testLatest     = "87654321"
+		)
+
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:00:00:00:00:00", nil)
+
+			gomock.InOrder(
+				mockDownloadClient.EXPECT().
+					Send(gomock.Any()).
+					Do(func(req http.Request) {
+						Expect(req.URL).To(ContainSubstring(PrivateAppStoreAPIPathDownload))
+					}).
+					Return(http.Result[downloadResult]{Data: downloadResult{FailureType: FailureTypeLicenseAlreadyExists}}, nil),
+				mockDownloadClient.EXPECT().
+					Send(gomock.Any()).
+					Do(func(req http.Request) {
+						Expect(req.URL).To(HavePrefix(testRedownload))
+					}).
+					Return(http.Result[downloadResult]{
+						Data: downloadResult{
+							Items: []downloadItemResult{
+								{
+									Metadata: map[string]interface{}{
+										"softwareVersionExternalIdentifiers": []interface{}{"12345678", testLatest},
+										"softwareVersionExternalIdentifier":  testLatest,
+									},
+								},
+							},
+						},
+					}, nil),
+			)
+		})
+
+		It("falls back to the redownload endpoint and returns versions", func() {
+			out, err := as.ListVersions(ListVersionsInput{RedownloadEndpoint: testRedownload})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.LatestExternalVersionID).To(Equal(testLatest))
+		})
+	})
 })


### PR DESCRIPTION
fixes #464 

## Problem

For a consumer Apple ID, `download`, `list-versions`, and `get-version-metadata` break for any app the account already holds a license for (Microsoft Teams, Office, and others): the `volumeStoreDownloadProduct` endpoint returns `failureType 5002`. `main` additionally maps `5002 → ErrPasswordTokenExpired`, which sends the CLI into a re-login loop before failing.

The earlier version of this PR *replaced* `volumeStoreDownloadProduct` with the bag's `redownloadProduct`. That fixes the licensed apps but breaks the opposite set: apps the account is **not** licensed for (e.g. YouTube, Instagram) are served by `volumeStore` but rejected by `redownload` with `"<App> No Longer Available"`. Neither endpoint serves every app — so this is a **fallback**, not a swap.

## What this does

`volumeStore` stays the primary endpoint (every app that works today keeps hitting the exact same endpoint — no regression). On `failureType 5002` it falls back to the bag-resolved `redownloadProduct`. The redownload response then disambiguates two different causes of 5002:

- **redownload serves the app** → it was genuinely licensed (Teams) → use it.
- **redownload also can't serve it** (`"No Longer Available"`) → the 5002 was a *transient* volumeStore hiccup → retry volumeStore.

This last point matters: `volumeStore` returns 5002 **intermittently** even for apps it can serve (≈1-in-8 calls, usually the first), so a naive "any 5002 → redownload" makes `list-versions` fail on an app that `download` succeeds on seconds later. The retry removes that inconsistency.

Other changes:
- `5002 → ErrPasswordTokenExpired` mapping removed (no more re-login loop).
- Per-endpoint version-pin key: `volumeStore` reads `externalVersionId`, `redownload` reads `appExtVrsId` (the other key is silently ignored). A single shared helper now sends the request and threads the right key.
- Empty results surface the endpoint's `customerMessage` (e.g. `"No Longer Available"`) instead of a generic `"invalid response"`.
- `download`, `list-versions`, and `get-version-metadata` share one `sendDownloadProduct` + `downloadProductItem` (the three POST the same payload and decode the same shape) — net **simplification**.
- `volumeStore` stays **hardcoded**: the bag advertises a `volumeStoreDownloadProduct` URL too, but it points at the enterprise/VPP host (`downloaddispatch…/ent/download`) which returns HTTP 500 for the client request shape. Only `redownloadProduct` is resolved from the bag.

## Why not resolve volumeStore from the bag, and why retry instead of switch

The transcript below was produced by a live run against a real consumer Apple ID (account redacted). It shows the bag's volumeStore URL is unusable (HTTP 500), that `5002` is deterministic for a licensed app (Teams, 12/12) but intermittent for a servable one (YouTube), and that the version-pin key is endpoint-specific.

## Verification

`go test ./... && go vet ./... && gofmt -l` are clean; the fallback is covered by unit specs across `download` / `list-versions` / `get-version-metadata` (including the tvOS key translation and the transient-5002 recovery). The transcript below also exercises every command end-to-end against a live account.

### Automated checks

```
$ gofmt -l pkg cmd                 # empty = formatted
$ go vet ./pkg/... ./cmd/...
OK
$ go test ./pkg/... ./cmd/...
ok  	github.com/majd/ipatool/v2/pkg/appstore
ok  	github.com/majd/ipatool/v2/pkg/http
ok  	github.com/majd/ipatool/v2/pkg/keychain
ok  	github.com/majd/ipatool/v2/pkg/log
ok  	github.com/majd/ipatool/v2/pkg/util
ok  	github.com/majd/ipatool/v2/pkg/util/machine
ok  	github.com/majd/ipatool/v2/pkg/util/operatingsystem
```

### Live end-to-end (real consumer Apple ID, account redacted)

```
#################### BACKGROUND (endpoint mechanics) ####################

## Endpoints advertised by the bag (init.itunes.apple.com/bag.xml)
  authenticateAccount          : https://auth.itunes.apple.com/auth/v1/native/fast
  redownloadProduct  (FALLBACK): https://downloaddispatch.itunes.apple.com/r/redownload
  volumeStoreDownloadProduct   : https://downloaddispatch.itunes.apple.com/WebObjects/DownloadDispatch.woa/wa/ent/download
                                 → HTTP 500, items=0 (enterprise/VPP shape; NOT usable for client downloads, so volumeStore stays hardcoded)
  hardcoded volumeStore (USED) : https://[p<pod>-]buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct

## volumeStore response stability — 12 calls/app (why a single 5002 must not switch endpoints)
  (sequence: . = served, X = 5002)
  app                            served    5002      other      sequence       verdict
  com.microsoft.skype.teams      0/12      12/12     0/12       XXXXXXXXXXXX   always 5002 → genuinely licensed → redownload
  com.google.ios.youtube         11/12     1/12      0/12       .X..........   intermittent 5002 → retry volumeStore
  com.spotify.client             12/12     0/12      0/12       ............   served by volumeStore
  note: Teams is deterministically 5002 (the #464 bug). volumeStore also returns 5002
        *intermittently* for apps it can otherwise serve (observed ~1-in-8 in repeated
        runs); that is why a 5002 triggers a redownload probe, and only a redownload that
        also cannot serve the app makes us retry volumeStore.

## Version-pin key is endpoint-specific (each endpoint reads only its own key)
  volumeStore (client ): externalVersionId  pins to 1862841 ✓   appExtVrsId        ignored, returns latest ✓
  redownload  (teams  ): appExtVrsId        pins to 823233975 ✓   externalVersionId  ignored, returns latest ✓


#################### FOREGROUND (CLI commands, real methods) ####################

## list-versions  (path each app takes shown in brackets)
  com.microsoft.skype.teams                ✓ 397 versions, latest=886178323  [volumeStore 5002 → redownload]
  com.google.ios.youtube         run 1/3   ✓ 596 versions, latest=885989940  [volumeStore (intermittent 5002, retried)]
  com.google.ios.youtube         run 2/3   ✓ 596 versions, latest=885989940  [volumeStore (intermittent 5002, retried)]
  com.google.ios.youtube         run 3/3   ✓ 596 versions, latest=885989940  [volumeStore (intermittent 5002, retried)]
  com.spotify.client                       ✓ 527 versions, latest=885637675  [volumeStore]

## get-version-metadata  (pins the latest version; reads the real IPA Info.plist)
  com.microsoft.skype.teams       ✓ version=8.9.2     released=2026-05-27  [volumeStore 5002 → redownload]
  com.google.ios.youtube          ✓ version=21.21.3   released=2026-05-22  [volumeStore (intermittent 5002, retried)]
  com.spotify.client              ✓ version=9.1.48    released=2026-05-11  [volumeStore]

## download  (the headline #464 path: licensed app via fallback → valid signed IPA)
  com.microsoft.skype.teams       ✓ 357.8 MB  Payload/TeamSpaceApp.app  sinf=true  iTunesMetadata=true  [volumeStore 5002 → redownload]
```

> Single-environment caveat (same as the original disclosure): Apple's responses on these endpoints are undocumented and vary by account state, storefront, and family-sharing posture. Independent confirmation on other accounts/apps would help validate generality.

---
Disclosure: implemented and verified end-to-end with Claude Code against a live test account in one environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #464 by adding a safe fallback to the bag’s `redownloadProduct` when `volumeStoreDownloadProduct` returns failureType 5002. Restores downloads, list-versions, and version metadata for licensed apps without breaking non-licensed apps.

- **Bug Fixes**
  - Keep `volumeStore` primary; on `5002`, try `redownloadProduct`. If `redownloadProduct` also can’t serve (empty failureType + “No Longer Available”), retry `volumeStore` to handle transient 5002s.
  - Remove `5002 → ErrPasswordTokenExpired` mapping to stop the re-login loop.
  - Surface endpoint `customerMessage` on empty results.

- **Refactors**
  - Add shared `sendDownloadProduct` and `downloadProductItem` used by `download`, `list-versions`, and `get-version-metadata` in `pkg/appstore`.
  - Use endpoint-specific version keys: `externalVersionId` for `volumeStore`, `appExtVrsId` for `redownloadProduct`.
  - `Bag` now returns the `redownloadProduct` URL; `cmd/*` fetch the bag and pass `RedownloadEndpoint` through to `pkg/appstore`.
  - Keep the `volumeStore` URL hardcoded; the bag’s `volumeStoreDownloadProduct` points to VPP and returns HTTP 500 for client requests.

<sup>Written for commit e8ca429161cb17bb9192a7bef2739b10e8a13d38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/majd/ipatool/pull/483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

