### PR TITLE
fix: update auth endpoint + stale lock file cleanup

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -54,8 +54,16 @@ func newLogger(format OutputFormat, verbose bool) log.Logger {
 
 // newCookieJar returns a new cookie jar instance.
 func newCookieJar(machine machine.Machine) http.CookieJar {
+	cookiePath := filepath.Join(machine.HomeDirectory(), ConfigDirectoryName, CookieJarFileName)
+	// Remove stale zero-byte lock files. The juju/go4/lock library only does
+	// PID-based stale detection when the file has content; a 0-byte lock file
+	// (left by a process killed between O_TRUNC and PID write) blocks forever.
+	lockPath := cookiePath + ".lock"
+	if fi, err := os.Stat(lockPath); err == nil && fi.Size() == 0 {
+		os.Remove(lockPath)
+	}
 	return util.Must(cookiejar.New(&cookiejar.Options{
-		Filename: filepath.Join(machine.HomeDirectory(), ConfigDirectoryName, CookieJarFileName),
+		Filename: cookiePath,
 	}))
 }
 

--- a/pkg/appstore/appstore_bag.go
+++ b/pkg/appstore/appstore_bag.go
@@ -36,9 +36,18 @@ func (t *appstore) Bag(input BagInput) (BagOutput, error) {
 	if endpoint == "" {
 		endpoint = res.Data.URLBag.AuthEndpoint
 	}
-	// The new auth endpoint base requires the /fast sub-path
-	if strings.Contains(endpoint, "auth.itunes.apple.com") && !strings.HasSuffix(endpoint, "/fast") {
-		endpoint = endpoint + "/fast"
+	// The new auth endpoint requires the /fast sub-path WITH a trailing slash.
+	// Without the trailing slash Apple returns 301 + an HTML redirect page
+	// (which the plist parser chokes on), and only the appstored UA gets a
+	// (download-grade) token. With the slash, the Configurator UA mints a
+	// commerce-grade token that buyProduct accepts.
+	if strings.Contains(endpoint, "auth.itunes.apple.com") {
+		if !strings.HasSuffix(endpoint, "/fast") && !strings.HasSuffix(endpoint, "/fast/") {
+			endpoint = endpoint + "/fast"
+		}
+		if !strings.HasSuffix(endpoint, "/") {
+			endpoint = endpoint + "/"
+		}
 	}
 
 	return BagOutput{

--- a/pkg/appstore/appstore_bag.go
+++ b/pkg/appstore/appstore_bag.go
@@ -32,13 +32,23 @@ func (t *appstore) Bag(input BagInput) (BagOutput, error) {
 		return BagOutput{}, fmt.Errorf("received unexpected status code: %d", res.StatusCode)
 	}
 
+	endpoint := res.Data.AuthEndpoint
+	if endpoint == "" {
+		endpoint = res.Data.URLBag.AuthEndpoint
+	}
+	// The new auth endpoint base requires the /fast sub-path
+	if strings.Contains(endpoint, "auth.itunes.apple.com") && !strings.HasSuffix(endpoint, "/fast") {
+		endpoint = endpoint + "/fast"
+	}
+
 	return BagOutput{
-		AuthEndpoint: res.Data.URLBag.AuthEndpoint,
+		AuthEndpoint: endpoint,
 	}, nil
 }
 
 type bagResult struct {
-	URLBag urlBag `plist:"urlBag,omitempty"`
+	URLBag       urlBag `plist:"urlBag,omitempty"`
+	AuthEndpoint string `plist:"authenticateAccount,omitempty"`
 }
 
 type urlBag struct {

--- a/pkg/appstore/appstore_login.go
+++ b/pkg/appstore/appstore_login.go
@@ -160,7 +160,7 @@ func (t *appstore) parseLoginResponse(res *http.Result[loginResult], attempt int
 func (t *appstore) loginRequest(email, password, authCode, guid, endpoint string, attempt int) http.Request {
 	return http.Request{
 		Method:         http.MethodPOST,
-		URL:            endpoint,
+		URL:            util.IfEmpty(endpoint, fmt.Sprintf("https://%s%s", PrivateAuthDomain, PrivateAuthPathNative)),
 		ResponseFormat: http.ResponseFormatXML,
 		Headers: map[string]string{
 			"Content-Type": "application/x-www-form-urlencoded",

--- a/pkg/appstore/appstore_login.go
+++ b/pkg/appstore/appstore_login.go
@@ -144,6 +144,8 @@ func (t *appstore) parseLoginResponse(res *http.Result[loginResult], attempt int
 		err = ErrAuthCodeRequired
 	} else if res.Data.FailureType == "" && res.Data.CustomerMessage == CustomerMessageAccountDisabled {
 		err = NewErrorWithMetadata(errors.New("account is disabled"), res)
+	} else if res.Data.FailureType == "" && res.Data.CustomerMessage == CustomerMessageActionSignInPage {
+		err = NewErrorWithMetadata(errors.New("account requires browser sign-in (2FA or Apple ID review required)"), res)
 	} else if res.Data.FailureType != "" {
 		if res.Data.CustomerMessage != "" {
 			err = NewErrorWithMetadata(errors.New(res.Data.CustomerMessage), res)

--- a/pkg/appstore/constants.go
+++ b/pkg/appstore/constants.go
@@ -25,6 +25,9 @@ const (
 	PrivateAppStoreAPIPathPurchase = "/WebObjects/MZFinance.woa/wa/buyProduct"
 	PrivateAppStoreAPIPathDownload = "/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct"
 
+	PrivateAuthDomain     = "auth." + iTunesAPIDomain
+	PrivateAuthPathNative = "/auth/v1/native/fast"
+
 	HTTPHeaderStoreFront = "X-Set-Apple-Store-Front"
 	HTTPHeaderPod        = "pod"
 

--- a/pkg/appstore/constants.go
+++ b/pkg/appstore/constants.go
@@ -13,6 +13,7 @@ const (
 	CustomerMessageAccountDisabled      = "Your account is disabled."
 	CustomerMessageSubscriptionRequired = "Subscription Required"
 	CustomerMessagePasswordChanged      = "Your password has changed."
+	CustomerMessageActionSignInPage     = "AMD-Action::SP"
 
 	iTunesAPIDomain     = "itunes.apple.com"
 	iTunesAPIPathSearch = "/search"
@@ -26,7 +27,7 @@ const (
 	PrivateAppStoreAPIPathDownload = "/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct"
 
 	PrivateAuthDomain     = "auth." + iTunesAPIDomain
-	PrivateAuthPathNative = "/auth/v1/native/fast"
+	PrivateAuthPathNative = "/auth/v1/native/fast/"
 
 	HTTPHeaderStoreFront = "X-Set-Apple-Store-Front"
 	HTTPHeaderPod        = "pod"

--- a/pkg/http/constants.go
+++ b/pkg/http/constants.go
@@ -8,5 +8,9 @@ const (
 )
 
 const (
+	// Configurator UA mints a commerce-grade password token (the "Aw..." token)
+	// that buyProduct accepts. The appstored UA only yields a download-grade
+	// token that buyProduct rejects with failureType 2034. Requires the auth
+	// endpoint to carry the trailing slash (see appstore_bag.go).
 	DefaultUserAgent = "Configurator/2.17 (Macintosh; OS X 15.2; 24C5089c) AppleWebKit/0620.1.16.11.6"
 )


### PR DESCRIPTION
## Problem

Apple's `26HOTFIX24` (June 2026) broke `ipatool` login for all accounts, and the obvious "switch to the appstored User-Agent" workaround silently breaks **purchase** afterward.

Two things changed:

1. **The `authenticateAccount` key moved to the Bag root** (it used to live under `urlBag`).
2. **The native auth endpoint requires a trailing slash:** `https://auth.itunes.apple.com/auth/v1/native/fast/`. Without it Apple returns `301` + an HTML redirect page, which surfaces as `something went wrong` / `unexpected hex digit 'h'`. The Bag now advertises `…/auth/v1/native` (no `/fast` at all), so the client must append `/fast/`.

The trailing slash is the load-bearing fix: with it, the **default `Configurator/2.17` UA logs in and mints a commerce-grade `passwordToken`** that `buyProduct` accepts. (Dodging the 301 by switching to `com.apple.appstored/1.0` makes login *look* fixed but yields a download-grade token that `buyProduct` rejects with `failureType 2034`.)

## Changes

- `pkg/appstore/appstore_bag.go`: read `authenticateAccount` from the Bag root **and** `urlBag`, and normalize the resolved endpoint to always end with `/fast/`.
- `pkg/appstore/constants.go`: `PrivateAuthPathNative` fallback gains the trailing slash; add the `AMD-Action::SP` customer-message constant.
- `pkg/appstore/appstore_login.go`: surface `AMD-Action::SP` as a clear "account requires browser sign-in" error.
- `cmd/common.go`: remove a stale zero-byte cookie lock file on startup (independent bug).

## Validation

Verified end-to-end (login + **purchase** + download) across many accounts with the stock Configurator UA — no anisette / kbsync / device signature needed. See #485 for the detailed write-up.