### PR TITLE
Fix auth handling for empty login token responses

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -78,7 +78,7 @@ func loginCmd() *cobra.Command {
 				}
 
 				dependencies.Logger.Verbose().
-					Str("password", password).
+					Bool("passwordProvided", password != "").
 					Str("email", email).
 					Str("authCode", util.IfEmpty(authCode, "<nil>")).
 					Msg("logging in")

--- a/pkg/appstore/appstore_login.go
+++ b/pkg/appstore/appstore_login.go
@@ -150,8 +150,14 @@ func (t *appstore) parseLoginResponse(res *http.Result[loginResult], attempt int
 		} else {
 			err = NewErrorWithMetadata(errors.New("something went wrong"), res)
 		}
-	} else if res.StatusCode != gohttp.StatusOK || res.Data.PasswordToken == "" || res.Data.DirectoryServicesID == "" {
-		err = NewErrorWithMetadata(errors.New("something went wrong"), res)
+	} else if res.StatusCode != gohttp.StatusOK {
+		err = NewErrorWithMetadata(fmt.Errorf("unexpected login status: %d", res.StatusCode), res)
+	} else if res.Data.PasswordToken == "" || res.Data.DirectoryServicesID == "" {
+		if authCode == "" {
+			err = ErrAuthCodeRequired
+		} else {
+			err = NewErrorWithMetadata(errors.New("login response did not include an App Store session token"), res)
+		}
 	}
 
 	return retry, redirect, err

--- a/pkg/appstore/appstore_login_test.go
+++ b/pkg/appstore/appstore_login_test.go
@@ -124,6 +124,42 @@ var _ = Describe("AppStore (Login)", func() {
 			})
 		})
 
+		When("store API returns OK without a session token before 2FA", func() {
+			BeforeEach(func() {
+				mockClient.EXPECT().
+					Send(gomock.Any()).
+					Return(http.Result[loginResult]{
+						StatusCode: 200,
+					}, nil)
+			})
+
+			It("requests an auth code", func() {
+				_, err := as.Login(LoginInput{
+					Password: testPassword,
+				})
+				Expect(err).To(Equal(ErrAuthCodeRequired))
+			})
+		})
+
+		When("store API returns OK without a session token after 2FA", func() {
+			BeforeEach(func() {
+				mockClient.EXPECT().
+					Send(gomock.Any()).
+					Return(http.Result[loginResult]{
+						StatusCode: 200,
+					}, nil)
+			})
+
+			It("returns an actionable invalid session response error", func() {
+				_, err := as.Login(LoginInput{
+					Password: testPassword,
+					AuthCode: "123456",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("login response did not include an App Store session token"))
+			})
+		})
+
 		When("store API indicates account is disabled", func() {
 			BeforeEach(func() {
 				mockClient.EXPECT().


### PR DESCRIPTION
## Summary
- avoid logging the Apple ID password in verbose auth logs
- treat empty successful login responses as an auth-code requirement before 2FA
- return a clearer error if the response is still missing session fields after an auth code

## Testing
- `go generate ./... && go test ./...`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves App Store login handling by treating empty 200 OK responses as an auth-code requirement, and returns a clear error if session fields are still missing after 2FA. Also removes raw password logging in verbose mode.

- **Bug Fixes**
  - Replace password value logging with `passwordProvided` boolean in `cmd/auth.go`.
  - In `pkg/appstore`, return `ErrAuthCodeRequired` when a 200 OK lacks session tokens before 2FA; after 2FA, return a clear “login response did not include an App Store session token” error.
  - Add tests for both pre- and post-2FA empty session token cases.

<sup>Written for commit 074d2464324b840eb9211bf147bc622b76aec8d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/majd/ipatool/pull/489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

