### PR TITLE
Fix App Store auth

### DIFF
--- a/pkg/appstore/appstore_bag.go
+++ b/pkg/appstore/appstore_bag.go
@@ -33,21 +33,30 @@ func (t *appstore) Bag(input BagInput) (BagOutput, error) {
 	}
 
 	return BagOutput{
-		AuthEndpoint: res.Data.URLBag.AuthEndpoint,
+		AuthEndpoint: res.Data.AuthEndpoint(),
 	}, nil
 }
 
 type bagResult struct {
-	URLBag urlBag `plist:"urlBag,omitempty"`
+	AuthenticateAccount string `plist:"authenticateAccount,omitempty"`
+	URLBag              urlBag `plist:"urlBag,omitempty"`
 }
 
 type urlBag struct {
 	AuthEndpoint string `plist:"authenticateAccount,omitempty"`
 }
 
+func (r bagResult) AuthEndpoint() string {
+	if r.AuthenticateAccount != "" {
+		return r.AuthenticateAccount
+	}
+
+	return r.URLBag.AuthEndpoint
+}
+
 func (*appstore) bagRequest(guid string) http.Request {
 	return http.Request{
-		URL:            fmt.Sprintf("https://%s%s?guid=%s", PrivateInitDomain, PrivateInitPath, guid),
+		URL:            fmt.Sprintf("https://%s%s?ix=6&guid=%s", PrivateInitDomain, PrivateInitPath, guid),
 		Method:         http.MethodGET,
 		ResponseFormat: http.ResponseFormatXML,
 		Headers: map[string]string{

--- a/pkg/appstore/appstore_bag_test.go
+++ b/pkg/appstore/appstore_bag_test.go
@@ -97,7 +97,7 @@ var _ = Describe("AppStore (Bag)", func() {
 				Send(gomock.Any()).
 				Do(func(req http.Request) {
 					Expect(req.Method).To(Equal(http.MethodGET))
-					Expect(req.URL).To(Equal("https://init.itunes.apple.com/bag.xml?guid=AABBCCDDEEFF"))
+					Expect(req.URL).To(Equal("https://init.itunes.apple.com/bag.xml?ix=6&guid=AABBCCDDEEFF"))
 					Expect(req.ResponseFormat).To(Equal(http.ResponseFormatXML))
 					Expect(req.Headers).To(HaveKeyWithValue("Accept", "application/xml"))
 				}).
@@ -107,6 +107,31 @@ var _ = Describe("AppStore (Bag)", func() {
 						URLBag: urlBag{
 							AuthEndpoint: testAuthEndpoint,
 						},
+					},
+				}, nil)
+		})
+
+		It("returns output", func() {
+			out, err := as.Bag(BagInput{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.AuthEndpoint).To(Equal(testAuthEndpoint))
+		})
+	})
+
+	When("request is successful with authenticateAccount in root", func() {
+		const testAuthEndpoint = "https://example.com"
+
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("aa:bb:cc:dd:ee:ff", nil)
+
+			mockBagClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[bagResult]{
+					StatusCode: gohttp.StatusOK,
+					Data: bagResult{
+						AuthenticateAccount: testAuthEndpoint,
 					},
 				}, nil)
 		})

--- a/pkg/appstore/appstore_login.go
+++ b/pkg/appstore/appstore_login.go
@@ -65,7 +65,7 @@ type loginResult struct {
 
 func (t *appstore) login(email, password, authCode, guid, endpoint string) (Account, error) {
 	redirect := ""
-
+	fastEndpoint := strings.Replace(endpoint, "/auth/v1/native", "/auth/v1/native/fast/", 1)
 	var (
 		err error
 		res http.Result[loginResult]
@@ -83,6 +83,13 @@ func (t *appstore) login(email, password, authCode, guid, endpoint string) (Acco
 		}
 
 		if retry, redirect, err = t.parseLoginResponse(&res, attempt, authCode); err != nil {
+			if authCode != "" && endpoint != fastEndpoint && missingLoginCredentials(res.Data) {
+				endpoint = fastEndpoint
+				redirect = ""
+				retry = true
+				err = nil
+				continue
+			}
 			return Account{}, err
 		}
 	}
@@ -150,11 +157,19 @@ func (t *appstore) parseLoginResponse(res *http.Result[loginResult], attempt int
 		} else {
 			err = NewErrorWithMetadata(errors.New("something went wrong"), res)
 		}
+	} else if (res.StatusCode == gohttp.StatusOK || res.StatusCode == gohttp.StatusNoContent) && authCode == "" && missingLoginCredentials(res.Data) {
+		err = ErrAuthCodeRequired
+	} else if (res.StatusCode == gohttp.StatusOK || res.StatusCode == gohttp.StatusNoContent) && missingLoginCredentials(res.Data) {
+		err = NewErrorWithMetadata(errors.New("login response is missing password token and directory services id"), res)
 	} else if res.StatusCode != gohttp.StatusOK || res.Data.PasswordToken == "" || res.Data.DirectoryServicesID == "" {
 		err = NewErrorWithMetadata(errors.New("something went wrong"), res)
 	}
 
 	return retry, redirect, err
+}
+
+func missingLoginCredentials(data loginResult) bool {
+	return data.PasswordToken == "" && data.DirectoryServicesID == ""
 }
 
 func (t *appstore) loginRequest(email, password, authCode, guid, endpoint string, attempt int) http.Request {


### PR DESCRIPTION
Use ix=6 bag auth endpoint and fast 2FA retry.

Tests:
- go test ./...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes App Store authentication by using the `ix=6` bag endpoint and adding a fast 2FA retry to stabilize login. Also supports Apple responses where `authenticateAccount` is returned at the root.

- **Bug Fixes**
  - Request bag with `ix=6` and resolve `authenticateAccount` from root or legacy `urlBag`.
  - Login auto-retries against `/auth/v1/native/fast/` when a 2FA code is provided but credentials are missing; clearer errors for “auth code required” vs. missing tokens.
  - Updated tests to expect the new bag URL and to cover root-level `authenticateAccount`.

<sup>Written for commit 7afc68b5523e0f8ba3d0945f82ec0d445566020b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/majd/ipatool/pull/494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

