### PR TITLE
Fix: "An unknown error has occurred" FailureType 5002

### DIFF
--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -244,7 +244,7 @@ func (*appstore) downloadRequest(acc Account, app App, guid string, externalVers
 		"creditDisplay": "",
 		"guid":          guid,
 		"salableAdamId": app.ID,
-		"serialNumber": "0",
+		"serialNumber":  "0",
 	}
 
 	if externalVersionID != "" {

--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -244,6 +244,7 @@ func (*appstore) downloadRequest(acc Account, app App, guid string, externalVers
 		"creditDisplay": "",
 		"guid":          guid,
 		"salableAdamId": app.ID,
+		"serialNumber": "0",
 	}
 
 	if externalVersionID != "" {

--- a/pkg/appstore/appstore_get_version_metadata.go
+++ b/pkg/appstore/appstore_get_version_metadata.go
@@ -74,7 +74,7 @@ func (t *appstore) getVersionMetadataRequest(acc Account, app App, guid string, 
 		"guid":              guid,
 		"salableAdamId":     app.ID,
 		"externalVersionId": version,
-		"serialNumber": "0"،
+		"serialNumber": "0",
 	}
 
 	podPrefix := ""

--- a/pkg/appstore/appstore_get_version_metadata.go
+++ b/pkg/appstore/appstore_get_version_metadata.go
@@ -74,7 +74,7 @@ func (t *appstore) getVersionMetadataRequest(acc Account, app App, guid string, 
 		"guid":              guid,
 		"salableAdamId":     app.ID,
 		"externalVersionId": version,
-		"serialNumber": "0",
+		"serialNumber":      "0",
 	}
 
 	podPrefix := ""

--- a/pkg/appstore/appstore_get_version_metadata.go
+++ b/pkg/appstore/appstore_get_version_metadata.go
@@ -74,6 +74,7 @@ func (t *appstore) getVersionMetadataRequest(acc Account, app App, guid string, 
 		"guid":              guid,
 		"salableAdamId":     app.ID,
 		"externalVersionId": version,
+		"serialNumber": "0"،
 	}
 
 	podPrefix := ""

--- a/pkg/appstore/appstore_list_versions.go
+++ b/pkg/appstore/appstore_list_versions.go
@@ -81,6 +81,7 @@ func (t *appstore) listVersionsRequest(acc Account, app App, guid string) http.R
 		"creditDisplay": "",
 		"guid":          guid,
 		"salableAdamId": app.ID,
+		"serialNumber": "0",
 	}
 
 	podPrefix := ""

--- a/pkg/appstore/appstore_list_versions.go
+++ b/pkg/appstore/appstore_list_versions.go
@@ -81,7 +81,7 @@ func (t *appstore) listVersionsRequest(acc Account, app App, guid string) http.R
 		"creditDisplay": "",
 		"guid":          guid,
 		"salableAdamId": app.ID,
-		"serialNumber": "0",
+		"serialNumber":  "0",
 	}
 
 	podPrefix := ""


### PR DESCRIPTION
## Description
Apple has recently implemented an additional verification check on the volumeStoreDownloadProduct endpoint for certain popular applications (such as Google and Microsoft apps, and others). If the required key is missing from the payload, the API returns a 5002 error. Other standard applications currently bypass this check and work without issues.

To resolve this and ensure the endpoint works consistently across all applications, we need to include the `serialNumber` key in the request payload.

## Changes Made
Added the `serialNumber` key to the payload with a default value of "0", which successfully bypasses the error.

## Future Considerations
Currently, setting "0" as the `serialNumber` value works perfectly. However, if Apple updates its validation logic in the future, we might need to implement a function to generate a random 10-digit value for this field.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes error 5002 (“An unknown error has occurred”) by adding the required `serialNumber` to App Store request payloads. Restores downloads, version listing, and version metadata for apps that enforce this check.

- **Bug Fixes**
  - Add `"serialNumber": "0"` to download, list versions, and version metadata requests.

<sup>Written for commit a8b0f3ff93deb869f56d367ca92a47f3279496ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/majd/ipatool/pull/500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

