### PR TITLE
Normalize App Store auth endpoint and hide credentials

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/avast/retry-go"
 	"github.com/majd/ipatool/v2/pkg/appstore"
-	"github.com/majd/ipatool/v2/pkg/util"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -77,10 +76,10 @@ func loginCmd() *cobra.Command {
 					}
 				}
 
+				// 密码和验证码属于高敏感凭据，即使开启 verbose 也不能写入日志。
 				dependencies.Logger.Verbose().
-					Str("password", password).
 					Str("email", email).
-					Str("authCode", util.IfEmpty(authCode, "<nil>")).
+					Bool("authCodeProvided", authCode != "").
 					Msg("logging in")
 
 				bag, err := dependencies.AppStore.Bag(appstore.BagInput{})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "ipatool",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/pkg/appstore/appstore_bag.go
+++ b/pkg/appstore/appstore_bag.go
@@ -33,12 +33,13 @@ func (t *appstore) Bag(input BagInput) (BagOutput, error) {
 	}
 
 	return BagOutput{
-		AuthEndpoint: res.Data.URLBag.AuthEndpoint,
+		AuthEndpoint: normalizeAuthEndpoint(res.Data.AuthEndpoint, res.Data.URLBag.AuthEndpoint),
 	}, nil
 }
 
 type bagResult struct {
-	URLBag urlBag `plist:"urlBag,omitempty"`
+	URLBag       urlBag `plist:"urlBag,omitempty"`
+	AuthEndpoint string `plist:"authenticateAccount,omitempty"`
 }
 
 type urlBag struct {

--- a/pkg/appstore/appstore_bag_test.go
+++ b/pkg/appstore/appstore_bag_test.go
@@ -118,6 +118,29 @@ var _ = Describe("AppStore (Bag)", func() {
 		})
 	})
 
+	When("request is successful with authenticateAccount at the root", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("aa:bb:cc:dd:ee:ff", nil)
+
+			mockBagClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[bagResult]{
+					StatusCode: gohttp.StatusOK,
+					Data: bagResult{
+						AuthEndpoint: "https://auth.itunes.apple.com/auth/v1/native",
+					},
+				}, nil)
+		})
+
+		It("returns the normalized native auth endpoint", func() {
+			out, err := as.Bag(BagInput{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.AuthEndpoint).To(Equal("https://auth.itunes.apple.com/auth/v1/native/fast/"))
+		})
+	})
+
 	When("request is successful but authenticateAccount is empty", func() {
 		BeforeEach(func() {
 			mockMachine.EXPECT().
@@ -132,10 +155,10 @@ var _ = Describe("AppStore (Bag)", func() {
 				}, nil)
 		})
 
-		It("returns empty auth endpoint", func() {
+		It("returns the fallback auth endpoint", func() {
 			out, err := as.Bag(BagInput{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(out.AuthEndpoint).To(BeEmpty())
+			Expect(out.AuthEndpoint).To(Equal("https://auth.itunes.apple.com/auth/v1/native/fast/"))
 		})
 	})
 })

--- a/pkg/appstore/appstore_login.go
+++ b/pkg/appstore/appstore_login.go
@@ -65,6 +65,7 @@ type loginResult struct {
 
 func (t *appstore) login(email, password, authCode, guid, endpoint string) (Account, error) {
 	redirect := ""
+	authEndpoint := normalizeAuthEndpoint(endpoint)
 
 	var (
 		err error
@@ -74,7 +75,7 @@ func (t *appstore) login(email, password, authCode, guid, endpoint string) (Acco
 	retry := true
 
 	for attempt := 1; retry && attempt <= 4; attempt++ {
-		request := t.loginRequest(email, password, authCode, guid, endpoint, attempt)
+		request := t.loginRequest(email, password, authCode, guid, authEndpoint, attempt)
 		request.URL, _ = util.IfEmpty(redirect, request.URL), ""
 		res, err = t.loginClient.Send(request)
 
@@ -148,10 +149,10 @@ func (t *appstore) parseLoginResponse(res *http.Result[loginResult], attempt int
 		if res.Data.CustomerMessage != "" {
 			err = NewErrorWithMetadata(errors.New(res.Data.CustomerMessage), res)
 		} else {
-			err = NewErrorWithMetadata(errors.New("something went wrong"), res)
+			err = NewErrorWithMetadata(fmt.Errorf("authentication failed with failure type %s", res.Data.FailureType), res)
 		}
 	} else if res.StatusCode != gohttp.StatusOK || res.Data.PasswordToken == "" || res.Data.DirectoryServicesID == "" {
-		err = NewErrorWithMetadata(errors.New("something went wrong"), res)
+		err = NewErrorWithMetadata(errors.New("authentication response did not include account credentials"), res)
 	}
 
 	return retry, redirect, err

--- a/pkg/appstore/appstore_login_test.go
+++ b/pkg/appstore/appstore_login_test.go
@@ -73,6 +73,9 @@ var _ = Describe("AppStore (Login)", func() {
 			BeforeEach(func() {
 				mockClient.EXPECT().
 					Send(gomock.Any()).
+					Do(func(req http.Request) {
+						Expect(req.URL).To(Equal("https://auth.itunes.apple.com/auth/v1/native/fast/"))
+					}).
 					Return(http.Result[loginResult]{}, errors.New(""))
 			})
 
@@ -121,6 +124,24 @@ var _ = Describe("AppStore (Login)", func() {
 					Password: testPassword,
 				})
 				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("authentication failed with failure type random-error"))
+			})
+		})
+
+		When("store API returns an empty successful response", func() {
+			BeforeEach(func() {
+				mockClient.EXPECT().
+					Send(gomock.Any()).
+					Return(http.Result[loginResult]{
+						StatusCode: 200,
+					}, nil)
+			})
+
+			It("returns a diagnostic error", func() {
+				_, err := as.Login(LoginInput{
+					Password: testPassword,
+				})
+				Expect(err).To(MatchError("authentication response did not include account credentials"))
 			})
 		})
 

--- a/pkg/appstore/auth_endpoint.go
+++ b/pkg/appstore/auth_endpoint.go
@@ -1,0 +1,42 @@
+package appstore
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// normalizeAuthEndpoint 兼容 Apple Bag 中新旧两种认证地址位置。
+// 2026 年 6 月起 native 端点必须使用 /fast/ 且保留末尾斜杠，否则 Apple 会返回空响应或 HTML 重定向。
+func normalizeAuthEndpoint(endpoints ...string) string {
+	for _, endpoint := range endpoints {
+		endpoint = strings.TrimSpace(endpoint)
+		if endpoint == "" {
+			continue
+		}
+
+		if normalized := normalizeNativeAuthEndpoint(endpoint); normalized != "" {
+			return normalized
+		}
+
+		return endpoint
+	}
+
+	return fmt.Sprintf("https://%s%s", PrivateAuthDomain, PrivateAuthPathNative)
+}
+
+func normalizeNativeAuthEndpoint(endpoint string) string {
+	parsed, err := url.Parse(endpoint)
+	if err != nil || !strings.EqualFold(parsed.Hostname(), PrivateAuthDomain) {
+		return ""
+	}
+
+	path := strings.TrimRight(parsed.Path, "/")
+	if !strings.HasSuffix(path, "/fast") {
+		path += "/fast"
+	}
+
+	parsed.Path = path + "/"
+
+	return parsed.String()
+}

--- a/pkg/appstore/auth_endpoint_test.go
+++ b/pkg/appstore/auth_endpoint_test.go
@@ -1,0 +1,31 @@
+package appstore
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Auth endpoint", func() {
+	It("falls back to the current native auth endpoint", func() {
+		Expect(normalizeAuthEndpoint()).To(Equal("https://auth.itunes.apple.com/auth/v1/native/fast/"))
+	})
+
+	It("normalizes native auth endpoints with the fast path and trailing slash", func() {
+		Expect(normalizeAuthEndpoint("https://auth.itunes.apple.com/auth/v1/native")).
+			To(Equal("https://auth.itunes.apple.com/auth/v1/native/fast/"))
+		Expect(normalizeAuthEndpoint("https://auth.itunes.apple.com/auth/v1/native/fast")).
+			To(Equal("https://auth.itunes.apple.com/auth/v1/native/fast/"))
+		Expect(normalizeAuthEndpoint("https://auth.itunes.apple.com/auth/v1/native/fast/")).
+			To(Equal("https://auth.itunes.apple.com/auth/v1/native/fast/"))
+	})
+
+	It("keeps legacy auth endpoints unchanged", func() {
+		endpoint := "https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/authenticate"
+		Expect(normalizeAuthEndpoint(endpoint)).To(Equal(endpoint))
+	})
+
+	It("uses the first non-empty endpoint", func() {
+		Expect(normalizeAuthEndpoint("", "https://auth.itunes.apple.com/auth/v1/native")).
+			To(Equal("https://auth.itunes.apple.com/auth/v1/native/fast/"))
+	})
+})

--- a/pkg/appstore/constants.go
+++ b/pkg/appstore/constants.go
@@ -24,6 +24,8 @@ const (
 	PrivateAppStoreAPIDomain       = "buy." + iTunesAPIDomain
 	PrivateAppStoreAPIPathPurchase = "/WebObjects/MZFinance.woa/wa/buyProduct"
 	PrivateAppStoreAPIPathDownload = "/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct"
+	PrivateAuthDomain              = "auth." + iTunesAPIDomain
+	PrivateAuthPathNative          = "/auth/v1/native/fast/"
 
 	HTTPHeaderStoreFront = "X-Set-Apple-Store-Front"
 	HTTPHeaderPod        = "pod"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Normalize the App Store authentication endpoint and hide sensitive credentials in logs. Requests now always use the native /fast/ endpoint and return clearer errors.

- **Bug Fixes**
  - Detect `authenticateAccount` at the root or in `urlBag`, and normalize to https://auth.itunes.apple.com/auth/v1/native/fast/ (with trailing slash); fall back to this when missing.
  - Send all login requests to the normalized endpoint.
  - Improve security and diagnostics: stop logging password/auth code; include failure type and report when credentials are missing in the response.

<sup>Written for commit 6b41ee640405e01e0c0edff882fb571b0936fec3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/majd/ipatool/pull/501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

