### PR TITLE
fix: resolve login authentication endpoint redirects and redundant bag requests

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -63,6 +63,11 @@ func loginCmd() *cobra.Command {
 				password = string(bytes)
 			}
 
+			bag, err := dependencies.AppStore.Bag(appstore.BagInput{})
+			if err != nil {
+				return fmt.Errorf("failed to get bag: %w", err)
+			}
+
 			var lastErr error
 
 			// nolint:wrapcheck
@@ -82,11 +87,6 @@ func loginCmd() *cobra.Command {
 					Str("email", email).
 					Str("authCode", util.IfEmpty(authCode, "<nil>")).
 					Msg("logging in")
-
-				bag, err := dependencies.AppStore.Bag(appstore.BagInput{})
-				if err != nil {
-					return fmt.Errorf("failed to get bag: %w", err)
-				}
 
 				output, err := dependencies.AppStore.Login(appstore.LoginInput{
 					Email:    email,

--- a/pkg/appstore/appstore_login.go
+++ b/pkg/appstore/appstore_login.go
@@ -35,7 +35,12 @@ func (t *appstore) Login(input LoginInput) (LoginOutput, error) {
 
 	guid := strings.ReplaceAll(strings.ToUpper(macAddr), ":", "")
 
-	acc, err := t.login(input.Email, input.Password, input.AuthCode, guid, input.Endpoint)
+	endpoint := input.Endpoint
+	if strings.Contains(endpoint, "/auth/v1/native") && !strings.HasSuffix(endpoint, "/fast/") {
+		endpoint = strings.TrimSuffix(endpoint, "/") + "/fast/"
+	}
+
+	acc, err := t.login(input.Email, input.Password, input.AuthCode, guid, endpoint)
 	if err != nil {
 		return LoginOutput{}, err
 	}
@@ -163,7 +168,7 @@ func (t *appstore) loginRequest(email, password, authCode, guid, endpoint string
 		URL:            endpoint,
 		ResponseFormat: http.ResponseFormatXML,
 		Headers: map[string]string{
-			"Content-Type": "application/x-www-form-urlencoded",
+			"Content-Type": "application/x-apple-plist",
 		},
 		Payload: &http.XMLPayload{
 			Content: map[string]interface{}{


### PR DESCRIPTION
This PR resolves issues with the auth login command failing due to changes in Apple's authentication backend and an inefficient retry mechanism.

1. Fixed Redundant Bag Requests during 2FA Inputs
Problem: The AppStore.Bag() call was placed inside the retry.Do loop in cmd/auth.go. When a user was prompted for a 2FA code, the block retried and triggered a second request to https://init.itunes.apple.com/bag.xml, causing rate-limiting/timeouts (read: operation timed out).
Fix: Moved the AppStore.Bag() retrieval outside/before the retry.Do loop so it only requests the API bag configuration once.
2. Added Trailing Slash to Native Authentication Endpoint
Problem: The bag configuration returns https://auth.itunes.apple.com/auth/v1/native for authentication. Sending a POST directly to this URL returns a 200 OK with Content-Length: 0 because it redirects the request, stripping the POST body.
Fix: Programmatically check the endpoint and append /fast/ (with a trailing slash) to native endpoints so it targets https://auth.itunes.apple.com/auth/v1/native/fast/. This allows Apple's servers to successfully process the credentials.
3. Adjusted Request Content-Type to match Plist Payload
Problem: The authentication request sent plist data but used "Content-Type": "application/x-www-form-urlencoded".
Fix: Changed the header to "Content-Type": "application/x-apple-plist" to match the actual XML/plist format of XMLPayload sent to Apple.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes login failures by handling Apple’s native auth redirect and preventing duplicate bag requests. Login is now reliable during 2FA and avoids rate limits/timeouts.

- **Bug Fixes**
  - Move `AppStore.Bag()` outside the retry loop to stop redundant bag requests during 2FA.
  - Normalize native auth endpoint to `/auth/v1/native/fast/` (ensure trailing slash) to avoid redirect that drops the POST body.
  - Set request header to `Content-Type: application/x-apple-plist` to match the plist payload.

<sup>Written for commit ee99c76c5e228d5f4839133de0d0bced74dc49a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/majd/ipatool/pull/502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

