### PR TITLE
Surface a clear error when Apple returns a non-plist login response (#480)

### DIFF
--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -170,6 +170,19 @@ func (c *client[R]) handleXMLResponse(res *http.Response) (Result[R], error) {
 
 	_, err = plist.Unmarshal(normalizedBody, &data)
 	if err != nil {
+		// Apple occasionally responds with an HTML error page (e.g. HTTP 404/5xx)
+		// instead of a property list, usually when the request is rate limited or
+		// temporarily blocked. Detect that case and surface a clear error rather
+		// than the misleading "failed to unmarshal xml" message.
+		if !looksLikePlist(normalizedBody) {
+			return Result[R]{}, fmt.Errorf(
+				"unexpected response from Apple (HTTP %d): the server did not return a property list, "+
+					"which usually means the request was rate limited or temporarily blocked - "+
+					"please wait a moment and try again",
+				res.StatusCode,
+			)
+		}
+
 		return Result[R]{}, fmt.Errorf("failed to unmarshal xml: %w", err)
 	}
 
@@ -208,6 +221,24 @@ func normalizeXMLPlistBody(body []byte) []byte {
 	}
 
 	return normalized
+}
+
+// looksLikePlist reports whether the body resembles a property list document.
+// It is used to distinguish a malformed plist from a completely unrelated
+// response (such as an HTML error page returned by Apple's edge servers).
+func looksLikePlist(body []byte) bool {
+	for _, marker := range [][]byte{
+		[]byte("<plist"),
+		[]byte("<dict"),
+		[]byte("<key>"),
+		[]byte("<Document"),
+	} {
+		if bytes.Contains(body, marker) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func extractEmbeddedPlist(body []byte) []byte {

--- a/pkg/http/client_test.go
+++ b/pkg/http/client_test.go
@@ -183,6 +183,29 @@ var _ = Describe("Client", Ordered, func() {
 				Expect(res.Data.Foo).To(Equal("bar"))
 			})
 
+			It("returns a clear error when Apple responds with a non-plist body", func() {
+				mockHandler = func(w http.ResponseWriter, _r *http.Request) {
+					w.Header().Add("Content-Type", "text/html")
+					w.WriteHeader(http.StatusNotFound)
+					_, err := w.Write([]byte("<html><head><title>404 Not Found</title></head>" +
+						"<body><center><h1>404 Not Found</h1></center></body></html>"))
+					Expect(err).ToNot(HaveOccurred())
+				}
+
+				sut := NewClient[xmlResult](Args{
+					CookieJar: mockCookieJar,
+				})
+				_, err := sut.Send(Request{
+					URL:            srv.URL,
+					Method:         MethodPOST,
+					ResponseFormat: ResponseFormatXML,
+				})
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unexpected response from Apple (HTTP 404)"))
+				Expect(err.Error()).ToNot(ContainSubstring("failed to unmarshal xml"))
+			})
+
 			It("returns error when content type is not supported", func() {
 				mockHandler = func(w http.ResponseWriter, _r *http.Request) {
 					w.Header().Add("Content-Type", "application/xyz")


### PR DESCRIPTION
## Summary

Fixes #480.

Apple's edge servers sometimes respond to the `authenticate` endpoint with an HTML error page (e.g. HTTP 404/5xx) instead of a property list — usually when a request is rate limited or temporarily blocked. The XML response handler fed those bodies straight into the plist parser, producing the cryptic and misleading error reported in the issue:

```
failed to unmarshal xml: plist: error parsing text property list: missing = in dictionary at line 0 character 6
```

This left users unable to tell that the real cause was a rate-limit / temporary block rather than a parsing bug in ipatool.

## Changes

- `pkg/http/client.go`: when `plist.Unmarshal` fails and the body doesn't resemble a property list (`looksLikePlist` helper), return an actionable error that names the HTTP status code and explains the likely cause, instead of the misleading XML error. Bodies that *do* look like a plist but fail to parse still return the original `failed to unmarshal xml` error.
- `pkg/http/client_test.go`: added a test covering an Apple-style HTML `404 Not Found` response.

This complements #481 (which handled the explicit `HTTP 429` case) by covering the other non-plist responses (404/5xx/HTML) Apple has been returning.

## Testing

- `go generate github.com/majd/ipatool/...`
- `go test github.com/majd/ipatool/...` — all packages pass
- `go vet ./pkg/http/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gt5Y3wRzpb5y4wWp6graEe

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #480 by returning a clear, actionable error when Apple responds with HTML or other non-plist bodies (e.g., 404/5xx). Users now see the HTTP status and guidance to retry, instead of the cryptic plist unmarshal error.

- **Bug Fixes**
  - In `pkg/http/client.go`, detect non-plist bodies via `looksLikePlist` and return an error naming the HTTP status and likely cause (rate limit/temporary block). Plist-shaped bodies still surface the original unmarshal error.
  - Added a test in `pkg/http/client_test.go` for an HTML 404 response to verify the new behavior.

<sup>Written for commit d5c58d7746cd91776792dc640d5dbf64fc8a564b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/majd/ipatool/pull/504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

