### PR TITLE
fix: handle sap guest timeouts

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -62,6 +62,8 @@ func loginCmd() *cobra.Command {
 				password = string(bytes)
 			}
 
+			dependencies.Logger.Log().Msg("preparing authentication; the first login may take a few minutes")
+
 			var lastErr error
 
 			// nolint:wrapcheck

--- a/internal/sap/machine/machine.go
+++ b/internal/sap/machine/machine.go
@@ -13,6 +13,8 @@ import (
 	"github.com/majd/ipatool/v2/internal/sap/unicorn"
 )
 
+const sapGuestTimeout = time.Minute
+
 const (
 	returnAddress = uint64(0x0000000100000000)
 	coreFPBase    = uint64(0x0000100000000000)
@@ -431,7 +433,10 @@ func (m *Machine) invoke(function uint64, arguments ...uint64) (uint64, error) {
 
 	m.services.resetFault()
 
-	if err := m.engine.StartBounded(function, returnAddress, 10*time.Second, 100_000_000); err != nil {
+	// SAP's cryptographic routines have input- and host-dependent instruction
+	// counts. Bound execution by wall time without rejecting legitimate work on
+	// slower machines for crossing a fixed instruction limit.
+	if err := m.engine.StartBounded(function, returnAddress, sapGuestTimeout, 0); err != nil {
 		if m.services.fault != nil {
 			return 0, m.services.fault
 		}

--- a/internal/sap/unicorn/engine.go
+++ b/internal/sap/unicorn/engine.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ebitengine/purego"
 )
 
+const queryTimeout = 4
+
 const (
 	archX86 = 4
 	mode64  = 8
@@ -28,12 +30,16 @@ const (
 	RegR9  = 107
 )
 
-var errEngineClosed = errors.New("unicorn engine is closed")
+var (
+	errTimeout      = errors.New("unicorn emulation timed out")
+	errEngineClosed = errors.New("unicorn engine is closed")
+)
 
 type api struct {
 	version  func(*uint32, *uint32) uint32
 	open     func(int32, int32, *uintptr) int32
 	close    func(uintptr) int32
+	query    func(uintptr, int32, *uint64) int32
 	ctl      func(uintptr, uint32, uint32) int32
 	strerror func(int32) string
 	memMap   func(uintptr, uint64, uint64, uint32) int32
@@ -126,6 +132,7 @@ func (e *Engine) register(handle uintptr) {
 	purego.RegisterLibFunc(&e.api.version, handle, "uc_version")
 	purego.RegisterLibFunc(&e.api.open, handle, "uc_open")
 	purego.RegisterLibFunc(&e.api.close, handle, "uc_close")
+	purego.RegisterLibFunc(&e.api.query, handle, "uc_query")
 	purego.RegisterLibFunc(&e.api.ctl, handle, "uc_ctl")
 	purego.RegisterLibFunc(&e.api.strerror, handle, "uc_strerror")
 	purego.RegisterLibFunc(&e.api.memMap, handle, "uc_mem_map")
@@ -259,7 +266,20 @@ func (e *Engine) StartBounded(begin, end uint64, timeout time.Duration, instruct
 
 	defer done()
 
-	return e.err(e.api.emuStart(handle, begin, end, microseconds, instructionLimit))
+	if err := e.err(e.api.emuStart(handle, begin, end, microseconds, instructionLimit)); err != nil {
+		return err
+	}
+
+	var timedOut uint64
+	if err := e.err(e.api.query(handle, queryTimeout, &timedOut)); err != nil {
+		return fmt.Errorf("query Unicorn timeout: %w", err)
+	}
+
+	if timedOut != 0 {
+		return fmt.Errorf("%w after %s", errTimeout, timeout)
+	}
+
+	return nil
 }
 
 func (e *Engine) Stop() error {

--- a/internal/sap/unicorn/engine_test.go
+++ b/internal/sap/unicorn/engine_test.go
@@ -242,3 +242,32 @@ func TestEngineExecutesX8664(t *testing.T) {
 		t.Fatalf("RAX = %#x, want %#x", value, uint64(0x1234))
 	}
 }
+
+func TestStartBoundedReportsTimeout(t *testing.T) {
+	engine := newTestEngine(t)
+	defer engine.Close()
+
+	const address = uint64(0x1100000)
+	if err := engine.MemMap(address, 0x1000); err != nil {
+		t.Fatal(err)
+	}
+
+	// jmp $-2
+	if err := engine.MemWrite(address, []byte{0xeb, 0xfe}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := engine.StartBounded(address, address+2, 10*time.Millisecond, 0)
+	if !errors.Is(err, errTimeout) {
+		t.Fatalf("StartBounded error = %v, want %v", err, errTimeout)
+	}
+
+	const completionAddress = address + 0x10
+	if err := engine.MemWrite(completionAddress, []byte{0xf4}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := engine.StartBounded(completionAddress, completionAddress+1, time.Second, 0); err != nil {
+		t.Fatalf("StartBounded after timeout: %v", err)
+	}
+}


### PR DESCRIPTION
## summary

- report Unicorn wall-clock timeouts explicitly
- use a one-minute wall-clock budget for SAP guest calls without a separate instruction limit
- tell users that first-time authentication may take a few minutes
- cover timeout reporting and engine reuse after a timeout

## testing

- `go generate ./...`
- `go test ./...`
- `go build ./...`
- `GOOS=windows GOARCH=amd64 go build ./...`
- `GOOS=windows GOARCH=arm64 go build ./...`

fixes #526