### PR TITLE
Add list-purchases command for owned apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,26 @@ Global Flags:
       --verbose           enables verbose logs
 ```
 
+To list apps owned by the authenticated account, use the `list-purchases` command. Results are ordered by purchase date, newest first.
+
+```
+List apps owned by the authenticated App Store account
+
+Usage:
+  ipatool list-purchases [flags]
+
+Flags:
+  -h, --help              help for list-purchases
+  -l, --max-results int   maximum number of apps to return per page (default 10)
+  -p, --page int          page of owned apps to return (default 1)
+
+Global Flags:
+      --format format                sets output format for command; can be 'text', 'json' (default text)
+      --keychain-passphrase string   passphrase for unlocking keychain
+      --non-interactive              run in non-interactive session
+      --verbose                      enables verbose logs
+```
+
 To obtain a list of availble app versions to download, use the `list-versions` command.
 
 ```

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,0 +1,13 @@
+package cmd
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Command Suite")
+}

--- a/cmd/purchases.go
+++ b/cmd/purchases.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/avast/retry-go"
+	"github.com/majd/ipatool/v2/pkg/appstore"
+	"github.com/spf13/cobra"
+)
+
+// nolint:wrapcheck
+func listPurchasesCmd() *cobra.Command {
+	var page, maxResults int
+
+	cmd := &cobra.Command{
+		Use:   "list-purchases",
+		Short: "List apps owned by the authenticated App Store account",
+		Args:  cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if page < 1 {
+				return errors.New("page must be greater than 0")
+			}
+			if maxResults < 1 {
+				return errors.New("max results must be greater than 0")
+			}
+			if maxResults > appstore.MaxOwnedAppsLimit {
+				return fmt.Errorf("max results must not exceed %d", appstore.MaxOwnedAppsLimit)
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var lastErr error
+
+			return retry.Do(func() error {
+				infoResult, err := dependencies.AppStore.AccountInfo()
+				if err != nil {
+					return err
+				}
+
+				acc := infoResult.Account
+				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
+					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{
+						Email:    acc.Email,
+						Password: acc.Password,
+					})
+					if err != nil {
+						return err
+					}
+
+					acc = loginResult.Account
+				}
+
+				output, err := dependencies.AppStore.OwnedApps(appstore.OwnedAppsInput{
+					Account: acc,
+					Page:    page,
+					Limit:   maxResults,
+				})
+				if err != nil {
+					return err
+				}
+
+				dependencies.Logger.Log().
+					Int("count", output.Count).
+					Int("totalCount", output.TotalCount).
+					Int("page", output.Page).
+					Array("apps", appstore.Apps(output.Results)).
+					Send()
+
+				return nil
+			},
+				retry.LastErrorOnly(true),
+				retry.DelayType(retry.FixedDelay),
+				retry.Delay(time.Millisecond),
+				retry.Attempts(2),
+				retry.RetryIf(func(err error) bool {
+					lastErr = err
+
+					return errors.Is(err, appstore.ErrPasswordTokenExpired)
+				}),
+			)
+		},
+	}
+
+	cmd.Flags().IntVarP(&maxResults, "max-results", "l", appstore.DefaultOwnedAppsLimit, "maximum number of apps to return per page")
+	cmd.Flags().IntVarP(&page, "page", "p", 1, "page of owned apps to return")
+
+	return cmd
+}

--- a/cmd/purchases_test.go
+++ b/cmd/purchases_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"github.com/majd/ipatool/v2/pkg/appstore"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("List Purchases command", func() {
+	It("uses the pagination defaults", func() {
+		cmd := listPurchasesCmd()
+
+		page, err := cmd.Flags().GetInt("page")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(page).To(Equal(1))
+
+		maxResults, err := cmd.Flags().GetInt("max-results")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(maxResults).To(Equal(appstore.DefaultOwnedAppsLimit))
+	})
+
+	DescribeTable("rejects invalid pagination",
+		func(flag, value, errorText string) {
+			cmd := listPurchasesCmd()
+			Expect(cmd.Flags().Set(flag, value)).To(Succeed())
+
+			err := cmd.PreRunE(cmd, nil)
+			Expect(err).To(MatchError(ContainSubstring(errorText)))
+		},
+		Entry("page below one", "page", "0", "page"),
+		Entry("max results below one", "max-results", "0", "max results"),
+		Entry("max results over limit", "max-results", "101", "100"),
+	)
+
+	It("is registered on the root command", func() {
+		cmd, _, err := rootCmd().Find([]string{"list-purchases"})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cmd.Name()).To(Equal("list-purchases"))
+	})
+})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,6 +47,7 @@ func rootCmd() *cobra.Command {
 
 	cmd.AddCommand(authCmd())
 	cmd.AddCommand(downloadCmd())
+	cmd.AddCommand(listPurchasesCmd())
 	cmd.AddCommand(purchaseCmd())
 	cmd.AddCommand(searchCmd())
 	cmd.AddCommand(ListVersionsCmd())

--- a/pkg/appstore/app.go
+++ b/pkg/appstore/app.go
@@ -1,15 +1,18 @@
 package appstore
 
 import (
+	"time"
+
 	"github.com/rs/zerolog"
 )
 
 type App struct {
-	ID       int64   `json:"trackId,omitempty"`
-	BundleID string  `json:"bundleId,omitempty"`
-	Name     string  `json:"trackName,omitempty"`
-	Version  string  `json:"version,omitempty"`
-	Price    float64 `json:"price,omitempty"`
+	ID           int64     `json:"trackId,omitempty"`
+	BundleID     string    `json:"bundleId,omitempty"`
+	Name         string    `json:"trackName,omitempty"`
+	Version      string    `json:"version,omitempty"`
+	Price        float64   `json:"price,omitempty"`
+	PurchaseDate time.Time `json:"purchaseDate,omitzero"`
 }
 
 type VersionHistoryInfo struct {
@@ -40,4 +43,8 @@ func (a App) MarshalZerologObject(event *zerolog.Event) {
 		Str("name", a.Name).
 		Str("version", a.Version).
 		Float64("price", a.Price)
+
+	if !a.PurchaseDate.IsZero() {
+		event.Time("purchaseDate", a.PurchaseDate)
+	}
 }

--- a/pkg/appstore/app_test.go
+++ b/pkg/appstore/app_test.go
@@ -3,6 +3,7 @@ package appstore
 import (
 	"bytes"
 	"encoding/json"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -40,12 +41,14 @@ var _ = Describe("App", func() {
 	})
 
 	It("marshalls app object", func() {
+		purchaseDate := time.Unix(1_700_000_000, 0).UTC()
 		app := App{
-			ID:       42,
-			BundleID: "app.bundle.id",
-			Name:     "app name",
-			Version:  "1.0",
-			Price:    0,
+			ID:           42,
+			BundleID:     "app.bundle.id",
+			Name:         "app name",
+			Version:      "1.0",
+			Price:        0,
+			PurchaseDate: purchaseDate,
 		}
 
 		buffer := bytes.NewBuffer([]byte{})
@@ -63,6 +66,22 @@ var _ = Describe("App", func() {
 		Expect(out["name"]).To(Equal("app name"))
 		Expect(out["version"]).To(Equal("1.0"))
 		Expect(out["price"]).To(Equal(float64(0)))
+		Expect(out["purchaseDate"]).To(Equal(purchaseDate.Format(time.RFC3339)))
+	})
+
+	It("omits an unknown purchase date", func() {
+		buffer := bytes.NewBuffer([]byte{})
+		logger := zerolog.New(buffer)
+		app := App{ID: 42}
+
+		event := logger.Log()
+		app.MarshalZerologObject(event)
+		event.Send()
+
+		var out map[string]interface{}
+		err := json.Unmarshal(buffer.Bytes(), &out)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).ToNot(HaveKey("purchaseDate"))
 	})
 
 	It("formats ipa name correctly", func() {

--- a/pkg/appstore/appstore.go
+++ b/pkg/appstore/appstore.go
@@ -18,6 +18,8 @@ type AppStore interface {
 	Lookup(input LookupInput) (LookupOutput, error)
 	// Search searches the App Store for apps matching the specified term.
 	Search(input SearchInput) (SearchOutput, error)
+	// OwnedApps lists apps owned by the authenticated account.
+	OwnedApps(input OwnedAppsInput) (OwnedAppsOutput, error)
 	// Purchase acquires a license for the desired app.
 	// Note: only free apps are supported.
 	Purchase(input PurchaseInput) error
@@ -41,6 +43,7 @@ type appstore struct {
 	downloadClient      http.Client[downloadResult]
 	platformClient      http.Client[platformVersionLookupResult]
 	bagClient           http.Client[bagResult]
+	ownedAppsClient     http.Client[[]byte]
 	httpClient          http.Client[interface{}]
 	actionSignerFactory ActionSignerFactory
 	machine             machine.Machine
@@ -73,6 +76,7 @@ func NewAppStore(args Args) AppStore {
 		downloadClient:      http.NewClient[downloadResult](clientArgs),
 		platformClient:      http.NewClient[platformVersionLookupResult](clientArgs),
 		bagClient:           http.NewClient[bagResult](clientArgs),
+		ownedAppsClient:     http.NewClient[[]byte](clientArgs),
 		httpClient:          http.NewClient[interface{}](clientArgs),
 		actionSignerFactory: actionSignerFactory,
 		machine:             args.Machine,

--- a/pkg/appstore/appstore_owned_apps.go
+++ b/pkg/appstore/appstore_owned_apps.go
@@ -1,0 +1,552 @@
+package appstore
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	gohttp "net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/majd/ipatool/v2/pkg/http"
+)
+
+const (
+	DefaultOwnedAppsLimit = 10
+	MaxOwnedAppsLimit     = 100
+
+	ownedAppsMediaKind = 131072
+)
+
+type OwnedAppsInput struct {
+	Account Account
+	Page    int
+	Limit   int
+}
+
+type OwnedAppsOutput struct {
+	Count      int
+	TotalCount int
+	Page       int
+	Results    []App
+}
+
+func (t *appstore) OwnedApps(input OwnedAppsInput) (OwnedAppsOutput, error) {
+	input, err := normalizeOwnedAppsInput(input)
+	if err != nil {
+		return OwnedAppsOutput{}, err
+	}
+
+	macAddress, err := t.machine.MacAddress()
+	if err != nil {
+		return OwnedAppsOutput{}, fmt.Errorf("failed to get mac address: %w", err)
+	}
+
+	guid, machineID, err := machineIdentity(macAddress)
+	if err != nil {
+		return OwnedAppsOutput{}, err
+	}
+
+	bag, err := t.bag(guid)
+	if err != nil {
+		return OwnedAppsOutput{}, fmt.Errorf("failed to get bag: %w", err)
+	}
+
+	if t.actionSignerFactory == nil {
+		return OwnedAppsOutput{}, errors.New("SAP action signer is not configured")
+	}
+
+	signer, err := t.actionSignerFactory(bag.SAPConfig, machineID)
+	if err != nil {
+		return OwnedAppsOutput{}, fmt.Errorf("failed to initialize SAP action signer: %w", err)
+	}
+
+	if signer == nil {
+		return OwnedAppsOutput{}, errors.New("SAP action signer factory returned nil")
+	}
+
+	apps, fetchErr := t.fetchOwnedApps(input.Account, guid, signer)
+	apps = ownedAppsSortedByPurchaseDate(apps)
+	pageApps := ownedAppsPage(apps, input.Page, input.Limit)
+	output := OwnedAppsOutput{
+		Count:      len(pageApps),
+		TotalCount: len(apps),
+		Page:       input.Page,
+		Results:    pageApps,
+	}
+	closeErr := signer.Close()
+
+	if closeErr != nil {
+		closeErr = fmt.Errorf("failed to close SAP action signer: %w", closeErr)
+	}
+
+	if fetchErr != nil {
+		if closeErr != nil {
+			return OwnedAppsOutput{}, errors.Join(fetchErr, closeErr)
+		}
+
+		return OwnedAppsOutput{}, fetchErr
+	}
+
+	if closeErr != nil {
+		return output, closeErr
+	}
+
+	return output, nil
+}
+
+func normalizeOwnedAppsInput(input OwnedAppsInput) (OwnedAppsInput, error) {
+	if input.Page == 0 {
+		input.Page = 1
+	}
+
+	if input.Limit == 0 {
+		input.Limit = DefaultOwnedAppsLimit
+	}
+
+	if input.Page < 1 {
+		return OwnedAppsInput{}, errors.New("page must be greater than 0")
+	}
+
+	if input.Limit < 1 {
+		return OwnedAppsInput{}, errors.New("limit must be greater than 0")
+	}
+
+	if input.Limit > MaxOwnedAppsLimit {
+		return OwnedAppsInput{}, fmt.Errorf("limit must not exceed %d", MaxOwnedAppsLimit)
+	}
+
+	return input, nil
+}
+
+func (t *appstore) fetchOwnedApps(acc Account, guid string, signer ActionSigner) ([]App, error) {
+	loginResult, err := t.ownedAppsClient.Send(t.ownedAppsLoginRequest(acc, guid))
+	if err != nil {
+		return nil, fmt.Errorf("failed to open purchase history session: %w", err)
+	}
+
+	if err := ownedAppsResponseError("purchase history login", loginResult); err != nil {
+		return nil, err
+	}
+
+	if err := ownedAppsDMAPStatusError("purchase history login", loginResult.Data); err != nil {
+		return nil, err
+	}
+
+	sessionID, ok, err := firstDMAPUint(loginResult.Data, "mlid")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse purchase history login response: %w", err)
+	}
+
+	if !ok || sessionID > math.MaxUint32 {
+		return nil, errors.New("purchase history login response did not contain a valid session ID")
+	}
+
+	query := fmt.Sprintf("('com.apple.itunes.extended\\-media\\-kind:%d')", ownedAppsMediaKind)
+
+	updateResult, err := t.ownedAppsClient.Send(t.ownedAppsUpdateRequest(acc, guid, uint32(sessionID), query, signer))
+	if err != nil {
+		return nil, fmt.Errorf("failed to update purchase history: %w", err)
+	}
+
+	if err := ownedAppsResponseError("purchase history update", updateResult); err != nil {
+		return nil, err
+	}
+
+	if err := ownedAppsDMAPStatusError("purchase history update", updateResult.Data); err != nil {
+		return nil, err
+	}
+
+	latestVersion, ok, err := firstDMAPUint(updateResult.Data, "musr")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse purchase history update response: %w", err)
+	}
+
+	if !ok || latestVersion > math.MaxUint32 {
+		return nil, errors.New("purchase history update response did not contain a valid revision")
+	}
+
+	itemsResult, err := t.ownedAppsClient.Send(t.ownedAppsItemsRequest(
+		acc,
+		guid,
+		uint32(sessionID),
+		uint32(latestVersion),
+		query,
+		time.Now(),
+		signer,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve purchase history items: %w", err)
+	}
+
+	if err := ownedAppsResponseError("purchase history items", itemsResult); err != nil {
+		return nil, err
+	}
+
+	if err := ownedAppsDMAPStatusError("purchase history items", itemsResult.Data); err != nil {
+		return nil, err
+	}
+
+	apps, err := parseOwnedApps(itemsResult.Data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse purchase history items response: %w", err)
+	}
+
+	return apps, nil
+}
+
+func (t *appstore) ownedAppsLoginRequest(acc Account, guid string) http.Request {
+	return http.Request{
+		URL:            PrivatePurchaseDAAPBaseURL + "/login",
+		Method:         http.MethodPOST,
+		ResponseFormat: http.ResponseFormatRaw,
+		Headers:        ownedAppsHeaders(acc, guid, time.Now()),
+	}
+}
+
+func (t *appstore) ownedAppsUpdateRequest(acc Account, guid string, sessionID uint32, query string, signer ActionSigner) http.Request {
+	body := []byte(fmt.Sprintf("session-id=%d&revision-number=(null)&query=%s", sessionID, query))
+	headers := ownedAppsHeaders(acc, guid, time.Now())
+	headers["Content-Type"] = "application/x-www-form-urlencoded"
+
+	return http.Request{
+		URL:            PrivatePurchaseDAAPBaseURL + "/update",
+		Method:         http.MethodPOST,
+		ResponseFormat: http.ResponseFormatRaw,
+		ActionSigner:   signer,
+		Headers:        headers,
+		Payload:        &http.RawPayload{Content: body},
+	}
+}
+
+func (t *appstore) ownedAppsItemsRequest(acc Account, guid string, sessionID, latestVersion uint32, query string, now time.Time, signer ActionSigner) http.Request {
+	headers := ownedAppsHeaders(acc, guid, now)
+	headers["Content-Type"] = "application/x-dmap-tagged"
+
+	return http.Request{
+		URL:            fmt.Sprintf("%s/databases/%d/items", PrivatePurchaseDAAPBaseURL, latestVersion),
+		Method:         http.MethodPOST,
+		ResponseFormat: http.ResponseFormatRaw,
+		ActionSigner:   signer,
+		Headers:        headers,
+		Payload: &http.RawPayload{Content: ownedAppsItemsBody(
+			sessionID,
+			latestVersion,
+			query,
+			now,
+		)},
+	}
+}
+
+func ownedAppsHeaders(acc Account, guid string, now time.Time) map[string]string {
+	utc := now.UTC()
+	_, offsetSeconds := now.Zone()
+
+	return map[string]string{
+		"Accept":                             "*/*",
+		"Accept-Language":                    "en-us",
+		"Client-Cloud-DAAP-Request-Reason":   "5",
+		"Client-Cloud-Purchase-Daap-Version": "1.1/Configurator-2.0",
+		"Client-DAAP-Version":                "3.12",
+		"Date":                               utc.Format(gohttp.TimeFormat),
+		"iCloud-DSID":                        acc.DirectoryServicesID,
+		"X-Apple-I-Client-Time":              utc.Format("2006-01-02T15:04:05Z"),
+		"X-Apple-I-Locale":                   "en_US",
+		"X-Apple-I-TimeZone":                 now.Location().String(),
+		"X-Apple-Store-Front":                acc.StoreFront,
+		"X-Apple-TZ":                         strconv.Itoa(offsetSeconds / 60),
+		"X-Dsid":                             acc.DirectoryServicesID,
+		"X-Guid":                             guid,
+		"X-Token":                            acc.PasswordToken,
+	}
+}
+
+func ownedAppsItemsBody(sessionID, latestVersion uint32, query string, now time.Time) []byte {
+	payload := make([]byte, 0, 73+len(query))
+	payload = append(payload, dmapUint32("mstc", uint32(now.Unix()))...)
+	payload = append(payload, dmapUint32("mlid", sessionID)...)
+	payload = append(payload, dmapUint8("mikd", 2)...)
+	payload = append(payload, dmapUint32("musr", latestVersion)...)
+	payload = append(payload, dmapUint32("mder", 0)...)
+	payload = append(payload, dmapString("mque", query)...)
+	payload = append(payload, dmapTag("aetl", nil)...)
+
+	return dmapTag("adsr", payload)
+}
+
+func dmapTag(name string, payload []byte) []byte {
+	result := make([]byte, 8+len(payload))
+	copy(result[:4], name)
+	binary.BigEndian.PutUint32(result[4:8], uint32(len(payload)))
+	copy(result[8:], payload)
+
+	return result
+}
+
+func dmapUint8(name string, value uint8) []byte {
+	return dmapTag(name, []byte{value})
+}
+
+func dmapUint32(name string, value uint32) []byte {
+	payload := make([]byte, 4)
+	binary.BigEndian.PutUint32(payload, value)
+
+	return dmapTag(name, payload)
+}
+
+func dmapString(name, value string) []byte {
+	return dmapTag(name, []byte(value))
+}
+
+func ownedAppsResponseError(label string, result http.Result[[]byte]) error {
+	if result.StatusCode == gohttp.StatusUnauthorized || result.StatusCode == gohttp.StatusForbidden {
+		return fmt.Errorf("%w: %s request returned HTTP %d", ErrPasswordTokenExpired, label, result.StatusCode)
+	}
+
+	if result.StatusCode != gohttp.StatusOK {
+		return fmt.Errorf("%s request returned HTTP %d", label, result.StatusCode)
+	}
+
+	return nil
+}
+
+func ownedAppsDMAPStatusError(label string, data []byte) error {
+	status, found, err := firstDMAPUint(data, "mstt")
+	if err != nil {
+		return fmt.Errorf("failed to parse %s response: %w", label, err)
+	}
+
+	if found && (status == gohttp.StatusUnauthorized || status == gohttp.StatusForbidden) {
+		return fmt.Errorf("%w: %s response returned DAAP status %d", ErrPasswordTokenExpired, label, status)
+	}
+
+	if found && status != gohttp.StatusOK {
+		return fmt.Errorf("%s response returned DAAP status %d", label, status)
+	}
+
+	return nil
+}
+
+func firstDMAPUint(data []byte, target string) (uint64, bool, error) {
+	var (
+		result uint64
+		found  bool
+	)
+
+	err := walkDMAP(data, 0, func(tag string, payload []byte) error {
+		if found || tag != target {
+			return nil
+		}
+
+		switch len(payload) {
+		case 4:
+			result = uint64(binary.BigEndian.Uint32(payload))
+		case 8:
+			result = binary.BigEndian.Uint64(payload)
+		default:
+			return fmt.Errorf("tag %s has invalid integer length %d", target, len(payload))
+		}
+
+		found = true
+
+		return nil
+	})
+
+	return result, found, err
+}
+
+func parseOwnedApps(data []byte) ([]App, error) {
+	apps := make([]App, 0)
+	seen := make(map[int64]struct{})
+
+	err := walkDMAP(data, 0, func(tag string, payload []byte) error {
+		if tag != "mlit" {
+			return nil
+		}
+
+		app, err := parseOwnedApp(payload)
+		if err != nil {
+			return err
+		}
+
+		if app.ID == 0 {
+			return nil
+		}
+
+		if _, ok := seen[app.ID]; ok {
+			return nil
+		}
+
+		seen[app.ID] = struct{}{}
+
+		apps = append(apps, app)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return apps, nil
+}
+
+func parseOwnedApp(data []byte) (App, error) {
+	var app App
+
+	err := walkDMAP(data, 0, func(tag string, payload []byte) error {
+		switch tag {
+		case "aeSI":
+			id, err := dmapInt64(payload)
+			if err != nil {
+				return fmt.Errorf("failed to parse owned app ID: %w", err)
+			}
+
+			app.ID = id
+		case "aeBI":
+			app.BundleID = string(payload)
+		case "aeLN":
+			app.Name = string(payload)
+		case "minm":
+			if app.Name == "" {
+				app.Name = string(payload)
+			}
+		case "aePd":
+			app.Version = string(payload)
+		case "asdp":
+			if len(payload) != 4 {
+				return fmt.Errorf("owned app purchase date has invalid length %d", len(payload))
+			}
+
+			app.PurchaseDate = time.Unix(int64(binary.BigEndian.Uint32(payload)), 0).UTC()
+		}
+
+		return nil
+	})
+
+	return app, err
+}
+
+func ownedAppsSortedByPurchaseDate(apps []App) []App {
+	sorted := append([]App(nil), apps...)
+	sort.SliceStable(sorted, func(left, right int) bool {
+		leftDate, rightDate := sorted[left].PurchaseDate, sorted[right].PurchaseDate
+		if leftDate.IsZero() {
+			return false
+		}
+
+		if rightDate.IsZero() {
+			return true
+		}
+
+		return leftDate.After(rightDate)
+	})
+
+	return sorted
+}
+
+func dmapInt64(payload []byte) (int64, error) {
+	switch len(payload) {
+	case 4:
+		return int64(binary.BigEndian.Uint32(payload)), nil
+	case 8:
+		value := binary.BigEndian.Uint64(payload)
+		if value > math.MaxInt64 {
+			return 0, errors.New("integer exceeds int64")
+		}
+
+		return int64(value), nil
+	default:
+		return 0, fmt.Errorf("invalid integer length %d", len(payload))
+	}
+}
+
+func walkDMAP(data []byte, depth int, visit func(tag string, payload []byte) error) error {
+	if depth > 16 {
+		return errors.New("DMAP nesting is too deep")
+	}
+
+	if len(data) == 0 {
+		return nil
+	}
+
+	for offset := 0; offset < len(data); {
+		if len(data)-offset < 8 {
+			return fmt.Errorf("truncated DMAP tag header at byte %d", offset)
+		}
+
+		tagBytes := data[offset : offset+4]
+		if !validDMAPTag(tagBytes) {
+			return fmt.Errorf("invalid DMAP tag at byte %d", offset)
+		}
+
+		length, remaining := uint64(binary.BigEndian.Uint32(data[offset+4:offset+8])), uint64(len(data)-offset-8)
+		if length > remaining {
+			return fmt.Errorf("DMAP tag %s length %d exceeds remaining response length %d", string(tagBytes), length, remaining)
+		}
+
+		end := offset + 8 + int(length)
+
+		tag, payload := string(tagBytes), data[offset+8:end]
+		if err := visit(tag, payload); err != nil {
+			return err
+		}
+
+		if isDMAPContainer(tag) {
+			if err := walkDMAP(payload, depth+1, visit); err != nil {
+				return err
+			}
+		}
+
+		offset = end
+	}
+
+	return nil
+}
+
+func validDMAPTag(tag []byte) bool {
+	if len(tag) != 4 {
+		return false
+	}
+
+	for _, character := range tag {
+		if character < 0x20 || character > 0x7e {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isDMAPContainer(tag string) bool {
+	switch tag {
+	case "adbs", "adsr", "aply", "avdb", "mbcl", "mccr", "mcty", "mdcl", "mlcl", "mlit", "mlog", "msrv", "mupd":
+		return true
+	default:
+		return false
+	}
+}
+
+func ownedAppsPage(apps []App, page, limit int) []App {
+	if page < 1 || limit < 1 {
+		return []App{}
+	}
+
+	pageIndex, pageSize := uint64(page-1), uint64(limit)
+	if pageIndex > uint64(len(apps))/pageSize {
+		return []App{}
+	}
+
+	start := pageIndex * pageSize
+	if start >= uint64(len(apps)) {
+		return []App{}
+	}
+
+	end := start + pageSize
+	if end > uint64(len(apps)) {
+		end = uint64(len(apps))
+	}
+
+	return append([]App(nil), apps[int(start):int(end)]...)
+}

--- a/pkg/appstore/appstore_owned_apps_test.go
+++ b/pkg/appstore/appstore_owned_apps_test.go
@@ -1,0 +1,396 @@
+package appstore
+
+import (
+	"encoding/binary"
+	"errors"
+	"math"
+	gohttp "net/http"
+	"time"
+
+	"github.com/majd/ipatool/v2/pkg/http"
+	"github.com/majd/ipatool/v2/pkg/util/machine"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+)
+
+var _ = Describe("AppStore (OwnedApps)", func() {
+	const (
+		testDSID       = "123456789"
+		testGUID       = "AABBCCDDEEFF"
+		testStoreFront = "143441"
+		testToken      = "password-token"
+		testSessionID  = uint32(42)
+		testRevision   = uint32(99)
+	)
+
+	var (
+		ctrl            *gomock.Controller
+		mockBagClient   *http.MockClient[bagResult]
+		mockOwnedClient *http.MockClient[[]byte]
+		mockMachine     *machine.MockMachine
+		signer          *stubActionSigner
+		as              *appstore
+	)
+
+	account := Account{
+		DirectoryServicesID: testDSID,
+		PasswordToken:       testToken,
+		StoreFront:          testStoreFront,
+	}
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockBagClient = http.NewMockClient[bagResult](ctrl)
+		mockOwnedClient = http.NewMockClient[[]byte](ctrl)
+		mockMachine = machine.NewMockMachine(ctrl)
+		signer = &stubActionSigner{}
+		as = &appstore{
+			bagClient:       mockBagClient,
+			ownedAppsClient: mockOwnedClient,
+			machine:         mockMachine,
+			actionSignerFactory: func(config SAPConfig, machineID []byte) (ActionSigner, error) {
+				Expect(config).To(Equal(validSAPConfig()))
+				Expect(machineID).To(Equal([]byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}))
+
+				return signer, nil
+			},
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	expectSignerSetup := func() {
+		mockMachine.EXPECT().
+			MacAddress().
+			Return("aa:bb:cc:dd:ee:ff", nil)
+		mockBagClient.EXPECT().
+			Send(gomock.Any()).
+			Do(func(req http.Request) {
+				Expect(req.URL).To(Equal("https://init.itunes.apple.com/bag.xml?guid=" + testGUID))
+			}).
+			Return(http.Result[bagResult]{
+				StatusCode: gohttp.StatusOK,
+				Data:       validBagResult(),
+			}, nil)
+	}
+
+	When("the account has more than one page of apps", func() {
+		It("sorts all apps by descending purchase date before returning the requested partial page", func() {
+			expectSignerSetup()
+
+			responseOrder := []int{5, 12, 1, 9, 3, 11, 2, 8, 4, 10, 6, 7}
+			apps := make([]App, 0, 12)
+			for _, index := range responseOrder {
+				apps = append(apps, App{
+					ID:           int64(1000 + index),
+					BundleID:     "com.example.app" + string(rune('a'+index-1)),
+					Name:         "DAAP app",
+					Version:      "1.0",
+					PurchaseDate: time.Unix(1_700_000_000+int64(index*60), 0).UTC(),
+				})
+			}
+
+			loginCall := mockOwnedClient.EXPECT().
+				Send(gomock.Any()).
+				Do(func(req http.Request) {
+					Expect(req.Method).To(Equal(http.MethodPOST))
+					Expect(req.URL).To(Equal(PrivatePurchaseDAAPBaseURL + "/login"))
+					Expect(req.ActionSigner).To(BeNil())
+					Expect(req.Payload).To(BeNil())
+					expectOwnedAppsHeaders(req.Headers, account, testGUID)
+				}).
+				Return(http.Result[[]byte]{
+					StatusCode: gohttp.StatusOK,
+					Data:       dmapTag("mlog", dmapUint32("mlid", testSessionID)),
+				}, nil)
+
+			updateCall := mockOwnedClient.EXPECT().
+				Send(gomock.Any()).
+				Do(func(req http.Request) {
+					Expect(req.Method).To(Equal(http.MethodPOST))
+					Expect(req.URL).To(Equal(PrivatePurchaseDAAPBaseURL + "/update"))
+					Expect(req.ActionSigner).To(BeIdenticalTo(signer))
+					Expect(req.Headers).To(HaveKeyWithValue("Content-Type", "application/x-www-form-urlencoded"))
+					expectOwnedAppsHeaders(req.Headers, account, testGUID)
+
+					payload, ok := req.Payload.(*http.RawPayload)
+					Expect(ok).To(BeTrue())
+					Expect(string(payload.Content)).To(Equal("session-id=42&revision-number=(null)&query=('com.apple.itunes.extended\\-media\\-kind:131072')"))
+				}).
+				Return(http.Result[[]byte]{
+					StatusCode: gohttp.StatusOK,
+					Data:       dmapTag("mupd", dmapUint32("musr", testRevision)),
+				}, nil)
+
+			itemsCall := mockOwnedClient.EXPECT().
+				Send(gomock.Any()).
+				Do(func(req http.Request) {
+					Expect(req.Method).To(Equal(http.MethodPOST))
+					Expect(req.URL).To(Equal(PrivatePurchaseDAAPBaseURL + "/databases/99/items"))
+					Expect(req.ActionSigner).To(BeIdenticalTo(signer))
+					Expect(req.Headers).To(HaveKeyWithValue("Content-Type", "application/x-dmap-tagged"))
+					expectOwnedAppsHeaders(req.Headers, account, testGUID)
+
+					payload, ok := req.Payload.(*http.RawPayload)
+					Expect(ok).To(BeTrue())
+					sessionID, found, err := firstDMAPUint(payload.Content, "mlid")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(found).To(BeTrue())
+					Expect(sessionID).To(Equal(uint64(testSessionID)))
+					revision, found, err := firstDMAPUint(payload.Content, "musr")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(found).To(BeTrue())
+					Expect(revision).To(Equal(uint64(testRevision)))
+				}).
+				Return(http.Result[[]byte]{
+					StatusCode: gohttp.StatusOK,
+					Data:       ownedAppsDMAPResponse(apps),
+				}, nil)
+
+			gomock.InOrder(loginCall, updateCall, itemsCall)
+
+			output, err := as.OwnedApps(OwnedAppsInput{
+				Account: account,
+				Page:    2,
+				Limit:   10,
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output.Count).To(Equal(2))
+			Expect(output.TotalCount).To(Equal(12))
+			Expect(output.Page).To(Equal(2))
+			Expect(output.Results).To(HaveLen(2))
+			Expect(output.Results[0].ID).To(Equal(int64(1002)))
+			Expect(output.Results[0].PurchaseDate).To(Equal(time.Unix(1_700_000_120, 0).UTC()))
+			Expect(output.Results[1].ID).To(Equal(int64(1001)))
+			Expect(output.Results[1].PurchaseDate).To(Equal(time.Unix(1_700_000_060, 0).UTC()))
+			Expect(signer.closeCalls).To(Equal(1))
+		})
+	})
+
+	When("the requested page is past the end", func() {
+		It("returns an empty page without a metadata lookup", func() {
+			expectSignerSetup()
+
+			gomock.InOrder(
+				mockOwnedClient.EXPECT().Send(gomock.Any()).Return(http.Result[[]byte]{
+					StatusCode: gohttp.StatusOK,
+					Data:       dmapTag("mlog", dmapUint32("mlid", testSessionID)),
+				}, nil),
+				mockOwnedClient.EXPECT().Send(gomock.Any()).Return(http.Result[[]byte]{
+					StatusCode: gohttp.StatusOK,
+					Data:       dmapTag("mupd", dmapUint32("musr", testRevision)),
+				}, nil),
+				mockOwnedClient.EXPECT().Send(gomock.Any()).Return(http.Result[[]byte]{
+					StatusCode: gohttp.StatusOK,
+					Data:       ownedAppsDMAPResponse([]App{{ID: 1}}),
+				}, nil),
+			)
+
+			output, err := as.OwnedApps(OwnedAppsInput{Account: account, Page: 2, Limit: 10})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output.Count).To(Equal(0))
+			Expect(output.TotalCount).To(Equal(1))
+			Expect(output.Results).To(BeEmpty())
+			Expect(signer.closeCalls).To(Equal(1))
+		})
+	})
+
+	When("the authenticated session is rejected", func() {
+		It("returns the password-token-expired error and closes the signer", func() {
+			expectSignerSetup()
+			mockOwnedClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[[]byte]{StatusCode: gohttp.StatusUnauthorized}, nil)
+
+			_, err := as.OwnedApps(OwnedAppsInput{Account: account})
+
+			Expect(errors.Is(err, ErrPasswordTokenExpired)).To(BeTrue())
+			Expect(signer.closeCalls).To(Equal(1))
+		})
+	})
+
+	When("the purchase history request and signer cleanup both fail", func() {
+		It("preserves both errors", func() {
+			expectSignerSetup()
+			requestErr := errors.New("request error")
+			cleanupErr := errors.New("cleanup error")
+			signer.closeErr = cleanupErr
+			mockOwnedClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[[]byte]{}, requestErr)
+
+			_, err := as.OwnedApps(OwnedAppsInput{Account: account})
+
+			Expect(errors.Is(err, requestErr)).To(BeTrue())
+			Expect(errors.Is(err, cleanupErr)).To(BeTrue())
+			Expect(signer.closeCalls).To(Equal(1))
+		})
+	})
+
+	When("the machine address cannot be read", func() {
+		It("returns an error before creating a signer", func() {
+			mockMachine.EXPECT().MacAddress().Return("", errors.New("machine error"))
+
+			_, err := as.OwnedApps(OwnedAppsInput{Account: account})
+
+			Expect(err).To(MatchError(ContainSubstring("failed to get mac address")))
+		})
+	})
+
+	DescribeTable("validates and defaults pagination",
+		func(input OwnedAppsInput, expected OwnedAppsInput, errorText string) {
+			actual, err := normalizeOwnedAppsInput(input)
+			if errorText != "" {
+				Expect(err).To(MatchError(ContainSubstring(errorText)))
+
+				return
+			}
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal(expected))
+		},
+		Entry("defaults page and limit", OwnedAppsInput{}, OwnedAppsInput{Page: 1, Limit: 10}, ""),
+		Entry("accepts the maximum limit", OwnedAppsInput{Page: 3, Limit: 100}, OwnedAppsInput{Page: 3, Limit: 100}, ""),
+		Entry("rejects a negative page", OwnedAppsInput{Page: -1, Limit: 10}, OwnedAppsInput{}, "page"),
+		Entry("rejects a negative limit", OwnedAppsInput{Page: 1, Limit: -1}, OwnedAppsInput{}, "limit"),
+		Entry("rejects a limit over 100", OwnedAppsInput{Page: 1, Limit: 101}, OwnedAppsInput{}, "100"),
+	)
+})
+
+var _ = Describe("owned-app DMAP parsing", func() {
+	It("parses app fields, ignores unknown fields, and removes duplicate IDs", func() {
+		item := make([]byte, 0, 128)
+		item = append(item, dmapString("zzzz", "unknown")...)
+		item = append(item, dmapUint64ForTest("aeSI", 123)...)
+		item = append(item, dmapString("aeBI", "com.example.app")...)
+		item = append(item, dmapString("aeLN", "Example")...)
+		item = append(item, dmapString("aePd", "1.2.3")...)
+		item = append(item, dmapUint32("asdp", 1_700_000_000)...)
+		listing := append(dmapTag("mlit", item), dmapTag("mlit", item)...)
+		response := dmapTag("adbs", dmapTag("mlcl", listing))
+
+		apps, err := parseOwnedApps(response)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(apps).To(Equal([]App{{
+			ID:           123,
+			BundleID:     "com.example.app",
+			Name:         "Example",
+			Version:      "1.2.3",
+			PurchaseDate: time.Unix(1_700_000_000, 0).UTC(),
+		}}))
+	})
+
+	It("rejects a malformed purchase date", func() {
+		item := append(dmapUint64ForTest("aeSI", 123), dmapTag("asdp", []byte{1, 2, 3})...)
+		response := dmapTag("adbs", dmapTag("mlcl", dmapTag("mlit", item)))
+
+		_, err := parseOwnedApps(response)
+
+		Expect(err).To(MatchError(ContainSubstring("purchase date has invalid length 3")))
+	})
+
+	It("rejects a truncated tag", func() {
+		_, err := parseOwnedApps([]byte("adbs\x00\x00\x00\x10short"))
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("exceeds remaining response length"))
+	})
+
+	It("rejects a protocol-level error status", func() {
+		response := dmapTag("mlog", dmapUint32("mstt", gohttp.StatusForbidden))
+
+		err := ownedAppsDMAPStatusError("purchase history login", response)
+
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ErrPasswordTokenExpired)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("DAAP status 403"))
+	})
+
+	It("preserves a partial last page", func() {
+		apps := []App{{ID: 1}, {ID: 2}, {ID: 3}}
+
+		Expect(ownedAppsPage(apps, 2, 2)).To(Equal([]App{{ID: 3}}))
+		Expect(ownedAppsPage(apps, 3, 2)).To(BeEmpty())
+		Expect(ownedAppsPage(apps, math.MaxInt, 100)).To(BeEmpty())
+	})
+
+	It("sorts missing dates last and preserves response order for ties", func() {
+		date := time.Unix(1_700_000_000, 0).UTC()
+		apps := []App{
+			{ID: 1},
+			{ID: 2, PurchaseDate: date},
+			{ID: 3, PurchaseDate: date.Add(time.Hour)},
+			{ID: 4, PurchaseDate: date},
+			{ID: 5},
+		}
+
+		sorted := ownedAppsSortedByPurchaseDate(apps)
+
+		Expect(sorted).To(Equal([]App{
+			{ID: 3, PurchaseDate: date.Add(time.Hour)},
+			{ID: 2, PurchaseDate: date},
+			{ID: 4, PurchaseDate: date},
+			{ID: 1},
+			{ID: 5},
+		}))
+		Expect(apps[0].ID).To(Equal(int64(1)))
+	})
+
+	It("builds the dynamic DMAP item request body", func() {
+		now := time.Unix(1_700_000_000, 0)
+		query := "('com.apple.itunes.extended\\-media\\-kind:131072')"
+		body := ownedAppsItemsBody(42, 99, query, now)
+
+		timestamp, found, err := firstDMAPUint(body, "mstc")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(timestamp).To(Equal(uint64(1_700_000_000)))
+		sessionID, found, err := firstDMAPUint(body, "mlid")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(sessionID).To(Equal(uint64(42)))
+	})
+})
+
+func expectOwnedAppsHeaders(headers map[string]string, account Account, guid string) {
+	Expect(headers).To(HaveKeyWithValue("X-Dsid", account.DirectoryServicesID))
+	Expect(headers).To(HaveKeyWithValue("iCloud-DSID", account.DirectoryServicesID))
+	Expect(headers).To(HaveKeyWithValue("X-Token", account.PasswordToken))
+	Expect(headers).To(HaveKeyWithValue("X-Apple-Store-Front", account.StoreFront))
+	Expect(headers).To(HaveKeyWithValue("X-Guid", guid))
+	Expect(headers).To(HaveKeyWithValue("Client-DAAP-Version", "3.12"))
+	Expect(headers).To(HaveKeyWithValue("Client-Cloud-Purchase-Daap-Version", "1.1/Configurator-2.0"))
+}
+
+func ownedAppsDMAPResponse(apps []App) []byte {
+	listing := make([]byte, 0, len(apps)*128)
+
+	for _, app := range apps {
+		item := make([]byte, 0, 128)
+		item = append(item, dmapUint64ForTest("aeSI", uint64(app.ID))...)
+		item = append(item, dmapString("aeBI", app.BundleID)...)
+		item = append(item, dmapString("aeLN", app.Name)...)
+		item = append(item, dmapString("aePd", app.Version)...)
+
+		if !app.PurchaseDate.IsZero() {
+			item = append(item, dmapUint32("asdp", uint32(app.PurchaseDate.Unix()))...)
+		}
+
+		listing = append(listing, dmapTag("mlit", item)...)
+	}
+
+	return dmapTag("adbs", dmapTag("mlcl", listing))
+}
+
+func dmapUint64ForTest(name string, value uint64) []byte {
+	payload := make([]byte, 8)
+	binary.BigEndian.PutUint64(payload, value)
+
+	return dmapTag(name, payload)
+}

--- a/pkg/appstore/constants.go
+++ b/pkg/appstore/constants.go
@@ -26,6 +26,8 @@ const (
 	PrivateAppStoreAPIPathPurchase = "/WebObjects/MZFinance.woa/wa/buyProduct"
 	PrivateAppStoreAPIPathDownload = "/WebObjects/MZFinance.woa/wa/volumeStoreDownloadProduct"
 
+	PrivatePurchaseDAAPBaseURL = "https://pd.itunes.apple.com/WebObjects/MZPurchaseDaap.woa/purchase"
+
 	HTTPHeaderStoreFront = "X-Set-Apple-Store-Front"
 	HTTPHeaderPod        = "pod"
 

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -134,11 +135,33 @@ func (c *client[R]) Send(req Request) (Result[R], error) {
 		return c.handleJSONResponse(res)
 	}
 
+	if req.ResponseFormat == ResponseFormatRaw {
+		return c.handleRawResponse(res)
+	}
+
 	if req.ResponseFormat == ResponseFormatXML {
 		return c.handleXMLResponse(res)
 	}
 
 	return Result[R]{}, fmt.Errorf("content type is not supported (%s)", req.ResponseFormat)
+}
+
+func (c *client[R]) handleRawResponse(res *http.Response) (Result[R], error) {
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return Result[R]{}, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	data, ok := any(body).(R)
+	if !ok {
+		return Result[R]{}, errors.New("raw response format requires a []byte result type")
+	}
+
+	return Result[R]{
+		StatusCode: res.StatusCode,
+		Headers:    responseHeaders(res),
+		Data:       data,
+	}, nil
 }
 
 func (c *client[R]) Do(req *http.Request) (*http.Response, error) {

--- a/pkg/http/client_test.go
+++ b/pkg/http/client_test.go
@@ -125,6 +125,43 @@ var _ = Describe("Client", Ordered, func() {
 				Expect(res.Data.Foo).To(Equal("bar"))
 			})
 
+			It("returns a raw response body", func() {
+				body := []byte{0x00, 0x01, 0xff}
+				mockHandler = func(w http.ResponseWriter, _r *http.Request) {
+					w.Header().Set("X-Test", "raw")
+					_, err := w.Write(body)
+					Expect(err).ToNot(HaveOccurred())
+				}
+
+				sut := NewClient[[]byte](Args{CookieJar: mockCookieJar})
+				res, err := sut.Send(Request{
+					URL:            srv.URL,
+					Method:         MethodGET,
+					ResponseFormat: ResponseFormatRaw,
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.Data).To(Equal(body))
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				Expect(res.Headers).To(HaveKeyWithValue("X-Test", "raw"))
+			})
+
+			It("rejects a raw response when the result type is not bytes", func() {
+				mockHandler = func(w http.ResponseWriter, _r *http.Request) {
+					_, err := w.Write([]byte("raw"))
+					Expect(err).ToNot(HaveOccurred())
+				}
+
+				sut := NewClient[struct{}](Args{CookieJar: mockCookieJar})
+				_, err := sut.Send(Request{
+					URL:            srv.URL,
+					Method:         MethodGET,
+					ResponseFormat: ResponseFormatRaw,
+				})
+
+				Expect(err).To(MatchError("raw response format requires a []byte result type"))
+			})
+
 			It("signs the exact serialized request body", func() {
 				signature := []byte("test-signature")
 				signer := &recordingActionSigner{signature: signature}
@@ -154,6 +191,36 @@ var _ = Describe("Client", Ordered, func() {
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(signer.calls).To(Equal(1))
+			})
+
+			It("signs an exact raw request body", func() {
+				body := []byte{0x61, 0x64, 0x73, 0x72, 0x00, 0x00, 0x00, 0x00}
+				signature := []byte("raw-signature")
+				signer := &recordingActionSigner{signature: signature}
+
+				mockHandler = func(w http.ResponseWriter, r *http.Request) {
+					defer GinkgoRecover()
+
+					actual, err := io.ReadAll(r.Body)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(actual).To(Equal(body))
+					Expect(r.Header.Get(HeaderAppleActionSignature)).To(Equal(base64.StdEncoding.EncodeToString(signature)))
+					_, err = w.Write([]byte("response"))
+					Expect(err).ToNot(HaveOccurred())
+				}
+
+				sut := NewClient[[]byte](Args{CookieJar: mockCookieJar})
+				_, err := sut.Send(Request{
+					URL:            srv.URL,
+					Method:         MethodPOST,
+					ResponseFormat: ResponseFormatRaw,
+					ActionSigner:   signer,
+					Payload:        &RawPayload{Content: body},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(signer.calls).To(Equal(1))
+				Expect(signer.data).To(Equal(body))
 			})
 
 			It("preserves an authentication pod redirect", func() {

--- a/pkg/http/constants.go
+++ b/pkg/http/constants.go
@@ -4,6 +4,7 @@ type ResponseFormat string
 
 const (
 	ResponseFormatJSON ResponseFormat = "json"
+	ResponseFormatRaw  ResponseFormat = "raw"
 	ResponseFormatXML  ResponseFormat = "xml"
 )
 

--- a/pkg/http/payload.go
+++ b/pkg/http/payload.go
@@ -21,6 +21,12 @@ type URLPayload struct {
 	Content map[string]interface{}
 }
 
+// RawPayload sends Content without applying an encoding. It is used by Apple
+// services whose request body is already serialized, such as DAAP/DMAP.
+type RawPayload struct {
+	Content []byte
+}
+
 func (p *XMLPayload) data() ([]byte, error) {
 	buffer := new(bytes.Buffer)
 
@@ -47,4 +53,8 @@ func (p *URLPayload) data() ([]byte, error) {
 	}
 
 	return []byte(params.Encode()), nil
+}
+
+func (p *RawPayload) data() ([]byte, error) {
+	return append([]byte(nil), p.Content...), nil
 }

--- a/pkg/http/payload_test.go
+++ b/pkg/http/payload_test.go
@@ -61,4 +61,18 @@ var _ = Describe("Payload", func() {
 			Expect(data).To(BeNil())
 		})
 	})
+
+	Context("Raw Payload", func() {
+		It("returns a copy of the data without encoding it", func() {
+			payload := &RawPayload{Content: []byte{0x00, 0x01, 0xff}}
+			sut = payload
+
+			data, err := sut.data()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(data).To(Equal([]byte{0x00, 0x01, 0xff}))
+
+			data[0] = 0xff
+			Expect(payload.Content).To(Equal([]byte{0x00, 0x01, 0xff}))
+		})
+	})
 })


### PR DESCRIPTION
## Summary

- Add an authenticated `list-purchases` command backed by signed SAP purchase-history requests
- Support pagination with a default of 10 and maximum of 100 apps per page
- Sort owned apps by purchase date, newest first, before pagination
- Add raw HTTP payload/response support, test coverage, and command documentation

closes #33 