### PR TITLE
Add visionOS search and download support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Release](https://img.shields.io/github/release/majd/ipatool.svg?label=Release)](https://GitHub.com/majd/ipatool/releases/)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/majd/ipatool/blob/main/LICENSE)
 
-`ipatool` is a command line tool that allows you to search for iOS apps on the [App Store](https://apps.apple.com) and download a copy of the app package, known as an _ipa_ file.
+`ipatool` is a command line tool that allows you to search for iOS, iPadOS, tvOS, and visionOS apps on the [App Store](https://apps.apple.com) and download a copy of the app package, known as an _ipa_ file.
 
 ![Demo](./resources/demo.gif)
 
@@ -65,15 +65,15 @@ Use "ipatool auth [command] --help" for more information about a command.
 To search for apps on the App Store, use the `search` command.
 
 ```
-Search for iOS and tvOS apps available on the App Store
+Search for iOS, iPadOS, tvOS, and visionOS apps available on the App Store
 
 Usage:
   ipatool search <term> [flags]
 
 Flags:
   -h, --help              help for search
-  -l, --limit int         maximum amount of search results to retrieve (default 5)
-      --platform string   Platform to search: iphone, ipad, or appletv
+  -l, --limit int         maximum amount of search results to retrieve; visionOS supports up to 12 (default 5)
+      --platform string   Platform to search: iphone (iOS), ipad (iPadOS), appletv (tvOS), or visionos
 
 Global Flags:
       --format format     sets output format for command; can be 'text', 'json' (default text)
@@ -142,18 +142,18 @@ Global Flags:
 To download a copy of the ipa file, use the `download` command.
 
 ```
-Download (encrypted) iOS and tvOS app packages from the App Store
+Download (encrypted) iOS, iPadOS, tvOS, and visionOS app packages from the App Store
 
 Usage:
   ipatool download [flags]
 
 Flags:
-  -i, --app-id int                   ID of the target iOS app (required)
-  -b, --bundle-identifier string     The bundle identifier of the target iOS app (overrides the app ID)
-      --external-version-id string   External version identifier of the target iOS app (defaults to latest version when not specified)
+  -i, --app-id int                   ID of the target app (required)
+  -b, --bundle-identifier string     The bundle identifier of the target app (overrides the app ID)
+      --external-version-id string   External version identifier of the target app (defaults to latest version when not specified)
   -h, --help                         help for download
   -o, --output string                The destination path of the downloaded app package
-      --platform string              Platform to download for: iphone, ipad, or appletv
+      --platform string              Platform to download for: iphone (iOS), ipad (iPadOS), appletv (tvOS), or visionos
       --purchase                     Obtain a license for the app if needed
 
 Global Flags:

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -24,7 +24,7 @@ func downloadCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "download",
-		Short: "Download (encrypted) iOS and tvOS app packages from the App Store",
+		Short: "Download (encrypted) iOS, iPadOS, tvOS, and visionOS app packages from the App Store",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if appID == 0 && bundleID == "" {
 				return errors.New("either the app ID or the bundle identifier must be specified")
@@ -149,11 +149,11 @@ func downloadCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().Int64VarP(&appID, "app-id", "i", 0, "ID of the target iOS app (required)")
-	cmd.Flags().StringVarP(&bundleID, "bundle-identifier", "b", "", "The bundle identifier of the target iOS app (overrides the app ID)")
+	cmd.Flags().Int64VarP(&appID, "app-id", "i", 0, "ID of the target app (required)")
+	cmd.Flags().StringVarP(&bundleID, "bundle-identifier", "b", "", "The bundle identifier of the target app (overrides the app ID)")
 	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "The destination path of the downloaded app package")
-	cmd.Flags().StringVar(&externalVersionID, "external-version-id", "", "External version identifier of the target iOS app (defaults to latest version when not specified)")
-	cmd.Flags().StringVar(&platformValue, "platform", "", "Platform to download for: iphone, ipad, or appletv")
+	cmd.Flags().StringVar(&externalVersionID, "external-version-id", "", "External version identifier of the target app (defaults to latest version when not specified)")
+	cmd.Flags().StringVar(&platformValue, "platform", "", "Platform to download for: iphone (iOS), ipad (iPadOS), appletv (tvOS), or visionos")
 	cmd.Flags().BoolVar(&acquireLicense, "purchase", false, "Obtain a license for the app if needed")
 
 	return cmd

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -14,7 +14,7 @@ func searchCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "search <term>",
-		Short: "Search for iOS and tvOS apps available on the App Store",
+		Short: "Search for iOS, iPadOS, tvOS, and visionOS apps available on the App Store",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			infoResult, err := dependencies.AppStore.AccountInfo()
@@ -46,8 +46,8 @@ func searchCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().Int64VarP(&limit, "limit", "l", 5, "maximum amount of search results to retrieve")
-	cmd.Flags().StringVar(&platformValue, "platform", "", "Platform to search: iphone, ipad, or appletv")
+	cmd.Flags().Int64VarP(&limit, "limit", "l", 5, "maximum amount of search results to retrieve; visionOS supports up to 12")
+	cmd.Flags().StringVar(&platformValue, "platform", "", "Platform to search: iphone (iOS), ipad (iPadOS), appletv (tvOS), or visionos")
 
 	return cmd
 }

--- a/pkg/appstore/appstore.go
+++ b/pkg/appstore/appstore.go
@@ -44,6 +44,7 @@ type appstore struct {
 	purchaseClient      http.Client[purchaseResult]
 	downloadClient      http.Client[downloadResult]
 	platformClient      http.Client[platformVersionLookupResult]
+	storefrontClient    http.Client[[]byte]
 	bagClient           http.Client[bagResult]
 	ownedAppsClient     http.Client[[]byte]
 	httpClient          http.Client[interface{}]
@@ -78,6 +79,7 @@ func NewAppStore(args Args) AppStore {
 		purchaseClient:      http.NewClient[purchaseResult](clientArgs),
 		downloadClient:      http.NewClient[downloadResult](clientArgs),
 		platformClient:      http.NewClient[platformVersionLookupResult](clientArgs),
+		storefrontClient:    http.NewClient[[]byte](clientArgs),
 		bagClient:           http.NewClient[bagResult](clientArgs),
 		ownedAppsClient:     http.NewClient[[]byte](clientArgs),
 		httpClient:          http.NewClient[interface{}](clientArgs),

--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -41,7 +41,7 @@ func (t *appstore) Download(input DownloadInput) (DownloadOutput, error) {
 	guid := strings.ReplaceAll(strings.ToUpper(macAddr), ":", "")
 
 	externalVersionID := input.ExternalVersionID
-	if externalVersionID == "" && input.Platform == PlatformAppleTV {
+	if externalVersionID == "" && (input.Platform == PlatformAppleTV || input.Platform == PlatformVisionOS) {
 		externalVersionID, err = t.lookupLatestExternalVersionID(input.Account, input.App, input.Platform)
 		if err != nil {
 			return DownloadOutput{}, fmt.Errorf("failed to resolve platform version: %w", err)
@@ -125,7 +125,14 @@ type platformPackageInfo struct {
 }
 
 func (*appstore) validatePackagePlatform(path string, platform Platform) error {
-	if platform != PlatformAppleTV {
+	var expectedPlatform string
+
+	switch platform {
+	case PlatformAppleTV:
+		expectedPlatform = "AppleTVOS"
+	case PlatformVisionOS:
+		expectedPlatform = "XROS"
+	default:
 		return nil
 	}
 
@@ -136,7 +143,7 @@ func (*appstore) validatePackagePlatform(path string, platform Platform) error {
 	defer reader.Close()
 
 	for _, file := range reader.File {
-		if !strings.HasPrefix(file.Name, "Payload/") || !strings.HasSuffix(file.Name, ".app/Info.plist") {
+		if !isTopLevelAppInfoPlist(file.Name) {
 			continue
 		}
 
@@ -164,13 +171,19 @@ func (*appstore) validatePackagePlatform(path string, platform Platform) error {
 		}
 
 		for _, supportedPlatform := range info.SupportedPlatforms {
-			if supportedPlatform == "AppleTVOS" {
+			if supportedPlatform == expectedPlatform {
 				return nil
 			}
 		}
 	}
 
-	return errors.New("downloaded package does not declare AppleTVOS support")
+	return fmt.Errorf("downloaded package does not declare %s support", expectedPlatform)
+}
+
+func isTopLevelAppInfoPlist(path string) bool {
+	parts := strings.Split(path, "/")
+
+	return len(parts) == 3 && parts[0] == "Payload" && strings.HasSuffix(parts[1], ".app") && parts[2] == "Info.plist"
 }
 
 type downloadItemResult struct {

--- a/pkg/appstore/appstore_download_test.go
+++ b/pkg/appstore/appstore_download_test.go
@@ -33,16 +33,17 @@ func (d *dummyFileInfo) Sys() interface{}   { return nil }
 
 var _ = Describe("AppStore (Download)", func() {
 	var (
-		ctrl               *gomock.Controller
-		mockKeychain       *keychain.MockKeychain
-		mockDownloadClient *http.MockClient[downloadResult]
-		mockPlatformClient *http.MockClient[platformVersionLookupResult]
-		mockPurchaseClient *http.MockClient[purchaseResult]
-		mockLoginClient    *http.MockClient[loginResult]
-		mockHTTPClient     *http.MockClient[interface{}]
-		mockOS             *operatingsystem.MockOperatingSystem
-		mockMachine        *machine.MockMachine
-		as                 AppStore
+		ctrl                 *gomock.Controller
+		mockKeychain         *keychain.MockKeychain
+		mockDownloadClient   *http.MockClient[downloadResult]
+		mockPlatformClient   *http.MockClient[platformVersionLookupResult]
+		mockStorefrontClient *http.MockClient[[]byte]
+		mockPurchaseClient   *http.MockClient[purchaseResult]
+		mockLoginClient      *http.MockClient[loginResult]
+		mockHTTPClient       *http.MockClient[interface{}]
+		mockOS               *operatingsystem.MockOperatingSystem
+		mockMachine          *machine.MockMachine
+		as                   AppStore
 	)
 
 	BeforeEach(func() {
@@ -50,20 +51,22 @@ var _ = Describe("AppStore (Download)", func() {
 		mockKeychain = keychain.NewMockKeychain(ctrl)
 		mockDownloadClient = http.NewMockClient[downloadResult](ctrl)
 		mockPlatformClient = http.NewMockClient[platformVersionLookupResult](ctrl)
+		mockStorefrontClient = http.NewMockClient[[]byte](ctrl)
 		mockLoginClient = http.NewMockClient[loginResult](ctrl)
 		mockPurchaseClient = http.NewMockClient[purchaseResult](ctrl)
 		mockHTTPClient = http.NewMockClient[interface{}](ctrl)
 		mockOS = operatingsystem.NewMockOperatingSystem(ctrl)
 		mockMachine = machine.NewMockMachine(ctrl)
 		as = &appstore{
-			keychain:       mockKeychain,
-			loginClient:    mockLoginClient,
-			purchaseClient: mockPurchaseClient,
-			downloadClient: mockDownloadClient,
-			platformClient: mockPlatformClient,
-			httpClient:     mockHTTPClient,
-			machine:        mockMachine,
-			os:             mockOS,
+			keychain:         mockKeychain,
+			loginClient:      mockLoginClient,
+			purchaseClient:   mockPurchaseClient,
+			downloadClient:   mockDownloadClient,
+			platformClient:   mockPlatformClient,
+			storefrontClient: mockStorefrontClient,
+			httpClient:       mockHTTPClient,
+			machine:          mockMachine,
+			os:               mockOS,
 		}
 	})
 
@@ -182,6 +185,74 @@ var _ = Describe("AppStore (Download)", func() {
 					ID: 42,
 				},
 				Platform: PlatformAppleTV,
+			})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("platform is visionOS", func() {
+		It("resolves and sends the visionOS external version id", func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			mockStorefrontClient.EXPECT().
+				Send(gomock.Any()).
+				Do(func(req http.Request) {
+					parsedURL, err := url.Parse(req.URL)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(parsedURL.Host).To(Equal("apps.apple.com"))
+					Expect(parsedURL.Path).To(Equal("/us/app/id42"))
+					Expect(parsedURL.Query().Get("platform")).To(Equal("vision"))
+					Expect(req.Method).To(Equal(http.MethodGET))
+					Expect(req.ResponseFormat).To(Equal(http.ResponseFormatRaw))
+				}).
+				Return(http.Result[[]byte]{
+					StatusCode: 200,
+					Data:       []byte(`<script type="application/json" id="serialized-server-data">[{"data":{"app":{"purchaseConfiguration":{"metricsPlatformDisplayStyle":"vision","appPlatforms":["vision"],"buyParams":"salableAdamId=42&appExtVrsId=987654"}}}}]</script>`),
+				}, nil)
+
+			mockDownloadClient.EXPECT().
+				Send(gomock.Any()).
+				Do(func(req http.Request) {
+					payload, ok := req.Payload.(*http.XMLPayload)
+					Expect(ok).To(BeTrue())
+					Expect(payload.Content["externalVersionId"]).To(Equal("987654"))
+				}).
+				Return(http.Result[downloadResult]{}, errors.New("request error"))
+
+			_, err := as.Download(DownloadInput{
+				Account: Account{
+					StoreFront: "143441",
+				},
+				App: App{
+					ID: 42,
+				},
+				Platform: PlatformVisionOS,
+			})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("uses an explicit external version id without a storefront lookup", func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			mockDownloadClient.EXPECT().
+				Send(gomock.Any()).
+				Do(func(req http.Request) {
+					payload, ok := req.Payload.(*http.XMLPayload)
+					Expect(ok).To(BeTrue())
+					Expect(payload.Content["externalVersionId"]).To(Equal("123456"))
+				}).
+				Return(http.Result[downloadResult]{}, errors.New("request error"))
+
+			_, err := as.Download(DownloadInput{
+				App: App{
+					ID: 42,
+				},
+				Platform:          PlatformVisionOS,
+				ExternalVersionID: "123456",
 			})
 			Expect(err).To(HaveOccurred())
 		})
@@ -628,25 +699,33 @@ var _ = Describe("AppStore (Download)", func() {
 	})
 
 	Describe("package platform validation", func() {
-		writePackage := func(platforms []string) string {
+		writePackageWithInfoPlists := func(infoPlists map[string][]string) string {
 			file, err := os.CreateTemp("", "ipatool-platform-*.ipa")
 			Expect(err).ToNot(HaveOccurred())
 			defer file.Close()
 
 			zipFile := zip.NewWriter(file)
-			w, err := zipFile.Create("Payload/Test.app/Info.plist")
-			Expect(err).ToNot(HaveOccurred())
+			for path, platforms := range infoPlists {
+				w, err := zipFile.Create(path)
+				Expect(err).ToNot(HaveOccurred())
 
-			info, err := plist.Marshal(map[string]interface{}{
-				"CFBundleSupportedPlatforms": platforms,
-			}, plist.BinaryFormat)
-			Expect(err).ToNot(HaveOccurred())
+				info, err := plist.Marshal(map[string]interface{}{
+					"CFBundleSupportedPlatforms": platforms,
+				}, plist.BinaryFormat)
+				Expect(err).ToNot(HaveOccurred())
 
-			_, err = w.Write(info)
-			Expect(err).ToNot(HaveOccurred())
+				_, err = w.Write(info)
+				Expect(err).ToNot(HaveOccurred())
+			}
+
 			Expect(zipFile.Close()).To(Succeed())
 
 			return file.Name()
+		}
+		writePackage := func(platforms []string) string {
+			return writePackageWithInfoPlists(map[string][]string{
+				"Payload/Test.app/Info.plist": platforms,
+			})
 		}
 
 		It("accepts AppleTVOS packages", func() {
@@ -664,6 +743,35 @@ var _ = Describe("AppStore (Download)", func() {
 			err := (&appstore{}).validatePackagePlatform(path, PlatformAppleTV)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("AppleTVOS"))
+		})
+
+		It("accepts XROS packages", func() {
+			path := writePackage([]string{"XROS"})
+			defer os.Remove(path)
+
+			err := (&appstore{}).validatePackagePlatform(path, PlatformVisionOS)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an error for packages without XROS support", func() {
+			path := writePackage([]string{"iPhoneOS"})
+			defer os.Remove(path)
+
+			err := (&appstore{}).validatePackagePlatform(path, PlatformVisionOS)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("XROS"))
+		})
+
+		It("ignores supported platforms declared only by an embedded app", func() {
+			path := writePackageWithInfoPlists(map[string][]string{
+				"Payload/Test.app/Info.plist":                    {"iPhoneOS"},
+				"Payload/Test.app/PlugIns/Vision.app/Info.plist": {"XROS"},
+			})
+			defer os.Remove(path)
+
+			err := (&appstore{}).validatePackagePlatform(path, PlatformVisionOS)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("XROS"))
 		})
 	})
 })

--- a/pkg/appstore/appstore_platform_version_lookup.go
+++ b/pkg/appstore/appstore_platform_version_lookup.go
@@ -66,6 +66,10 @@ func (t *appstore) lookupLatestExternalVersionID(acc Account, app App, platform 
 		return "", fmt.Errorf("failed to resolve the country code: %w", err)
 	}
 
+	if platform == PlatformVisionOS {
+		return t.lookupLatestVisionOSExternalVersionID(app.ID, countryCode)
+	}
+
 	request, err := t.platformVersionLookupRequest(app.ID, countryCode, platform)
 	if err != nil {
 		return "", fmt.Errorf("failed to create platform version lookup request: %w", err)
@@ -101,6 +105,30 @@ func (t *appstore) lookupLatestExternalVersionID(acc Account, app App, platform 
 
 	if externalVersionID == "" {
 		return "", NewErrorWithMetadata(errors.New("platform version lookup returned no external version id"), res)
+	}
+
+	return externalVersionID, nil
+}
+
+func (t *appstore) lookupLatestVisionOSExternalVersionID(appID int64, countryCode string) (string, error) {
+	request := http.Request{
+		URL:            visionProductURL(appID, countryCode),
+		Method:         http.MethodGET,
+		ResponseFormat: http.ResponseFormatRaw,
+	}
+
+	res, err := t.storefrontClient.Send(request)
+	if err != nil {
+		return "", fmt.Errorf("visionOS version lookup request failed: %w", err)
+	}
+
+	if res.StatusCode != gohttp.StatusOK {
+		return "", NewErrorWithMetadata(errors.New("visionOS version lookup request failed"), res)
+	}
+
+	externalVersionID, err := visionExternalVersionID(res.Data, appID)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse visionOS version lookup response: %w", err)
 	}
 
 	return externalVersionID, nil

--- a/pkg/appstore/appstore_search.go
+++ b/pkg/appstore/appstore_search.go
@@ -6,6 +6,7 @@ import (
 	gohttp "net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/majd/ipatool/v2/pkg/http"
 )
@@ -28,6 +29,10 @@ func (t *appstore) Search(input SearchInput) (SearchOutput, error) {
 		return SearchOutput{}, fmt.Errorf("country code is invalid: %w", err)
 	}
 
+	if input.Platform == PlatformVisionOS {
+		return t.searchVisionOS(input, countryCode)
+	}
+
 	request, err := t.searchRequest(input.Term, countryCode, input.Limit, input.Platform)
 	if err != nil {
 		return SearchOutput{}, fmt.Errorf("failed to create search request: %w", err)
@@ -45,6 +50,67 @@ func (t *appstore) Search(input SearchInput) (SearchOutput, error) {
 	return SearchOutput{
 		Count:   res.Data.Count,
 		Results: res.Data.Results,
+	}, nil
+}
+
+func (t *appstore) searchVisionOS(input SearchInput, countryCode string) (SearchOutput, error) {
+	request := http.Request{
+		URL:            visionSearchURL(input.Term, countryCode),
+		Method:         http.MethodGET,
+		ResponseFormat: http.ResponseFormatRaw,
+	}
+
+	res, err := t.storefrontClient.Send(request)
+	if err != nil {
+		return SearchOutput{}, fmt.Errorf("visionOS search request failed: %w", err)
+	}
+
+	if res.StatusCode != gohttp.StatusOK {
+		return SearchOutput{}, NewErrorWithMetadata(errors.New("visionOS search request failed"), res)
+	}
+
+	storefrontApps, err := storefrontVisionApps(res.Data, input.Limit)
+	if err != nil {
+		return SearchOutput{}, fmt.Errorf("failed to parse visionOS search results: %w", err)
+	}
+
+	if len(storefrontApps) == 0 {
+		return SearchOutput{Results: []App{}}, nil
+	}
+
+	ids := make([]string, 0, len(storefrontApps))
+	for _, app := range storefrontApps {
+		ids = append(ids, strconv.FormatInt(app.ID, 10))
+	}
+
+	lookupRequest, err := t.lookupIDsRequest(ids, countryCode, PlatformVisionOS)
+	if err != nil {
+		return SearchOutput{}, fmt.Errorf("failed to create visionOS metadata request: %w", err)
+	}
+
+	lookupResponse, err := t.searchClient.Send(lookupRequest)
+	if err != nil {
+		return SearchOutput{}, fmt.Errorf("visionOS metadata request failed: %w", err)
+	}
+
+	if lookupResponse.StatusCode != gohttp.StatusOK {
+		return SearchOutput{}, NewErrorWithMetadata(errors.New("visionOS metadata request failed"), lookupResponse)
+	}
+
+	hydrated := make(map[int64]App, len(lookupResponse.Data.Results))
+	for _, app := range lookupResponse.Data.Results {
+		hydrated[app.ID] = app
+	}
+
+	for index, app := range storefrontApps {
+		if metadata, ok := hydrated[app.ID]; ok {
+			storefrontApps[index] = metadata
+		}
+	}
+
+	return SearchOutput{
+		Count:   len(storefrontApps),
+		Results: storefrontApps,
 	}, nil
 }
 
@@ -80,4 +146,22 @@ func (t *appstore) searchURL(term, countryCode string, limit int64, platform Pla
 	params.Add("country", countryCode)
 
 	return fmt.Sprintf("https://%s%s?%s", iTunesAPIDomain, iTunesAPIPathSearch, params.Encode()), nil
+}
+
+func (*appstore) lookupIDsRequest(ids []string, countryCode string, platform Platform) (http.Request, error) {
+	entity, err := platform.lookupEntity()
+	if err != nil {
+		return http.Request{}, err
+	}
+
+	params := url.Values{}
+	params.Add("entity", entity)
+	params.Add("id", strings.Join(ids, ","))
+	params.Add("country", countryCode)
+
+	return http.Request{
+		URL:            fmt.Sprintf("https://%s%s?%s", iTunesAPIDomain, iTunesAPIPathLookup, params.Encode()),
+		Method:         http.MethodGET,
+		ResponseFormat: http.ResponseFormatJSON,
+	}, nil
 }

--- a/pkg/appstore/appstore_search_test.go
+++ b/pkg/appstore/appstore_search_test.go
@@ -12,16 +12,19 @@ import (
 
 var _ = Describe("AppStore (Search)", func() {
 	var (
-		ctrl       *gomock.Controller
-		mockClient *http.MockClient[searchResult]
-		as         AppStore
+		ctrl                 *gomock.Controller
+		mockClient           *http.MockClient[searchResult]
+		mockStorefrontClient *http.MockClient[[]byte]
+		as                   AppStore
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockClient = http.NewMockClient[searchResult](ctrl)
+		mockStorefrontClient = http.NewMockClient[[]byte](ctrl)
 		as = &appstore{
-			searchClient: mockClient,
+			searchClient:     mockClient,
+			storefrontClient: mockStorefrontClient,
 		}
 	})
 
@@ -97,6 +100,70 @@ var _ = Describe("AppStore (Search)", func() {
 				Platform: PlatformAppleTV,
 			})
 			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("platform is visionOS", func() {
+		const searchPage = `<html><script type="application/json" id="serialized-server-data">{
+			"data":[{"data":{"shelves":[{"items":[
+				{"$kind":"EditorialItem","lockup":{"adamId":"999"},"purchaseConfiguration":{"metricsPlatformDisplayStyle":"vision","appPlatforms":["vision"],"buyParams":"salableAdamId=999&appExtVrsId=9990"}},
+				{"$kind":"AppSearchResult","lockup":{"adamId":"200","bundleId":"fallback.two","title":"Fallback Two"},"purchaseConfiguration":{"metricsPlatformDisplayStyle":"vision","appPlatforms":["vision"],"buyParams":"salableAdamId=200&appExtVrsId=2000"}},
+				{"$kind":"AppSearchResult","lockup":{"adamId":"300","bundleId":"wrong.platform","title":"Wrong Platform"},"purchaseConfiguration":{"metricsPlatformDisplayStyle":"ios","appPlatforms":["iphone"],"buyParams":"salableAdamId=300&appExtVrsId=3000"}},
+				{"$kind":"AppSearchResult","lockup":{"adamId":"100","bundleId":"fallback.one","title":"Fallback One"},"purchaseConfiguration":{"metricsPlatformDisplayStyle":"vision","appPlatforms":["vision"],"buyParams":"salableAdamId=100&appExtVrsId=1000"}},
+				{"$kind":"AppSearchResult","lockup":{"adamId":"400","bundleId":"limited.out","title":"Limited Out"},"purchaseConfiguration":{"metricsPlatformDisplayStyle":"vision","appPlatforms":["vision"],"buyParams":"salableAdamId=400&appExtVrsId=4000"}}
+			] }]}}]}
+		</script></html>`
+
+		BeforeEach(func() {
+			mockStorefrontClient.EXPECT().
+				Send(gomock.Any()).
+				Do(func(req http.Request) {
+					parsedURL, err := url.Parse(req.URL)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(parsedURL.Host).To(Equal("apps.apple.com"))
+					Expect(parsedURL.Path).To(Equal("/us/vision/search"))
+					Expect(parsedURL.Query().Get("term")).To(Equal("spatial notes"))
+					Expect(req.Method).To(Equal(http.MethodGET))
+					Expect(req.ResponseFormat).To(Equal(http.ResponseFormatRaw))
+				}).
+				Return(http.Result[[]byte]{StatusCode: 200, Data: []byte(searchPage)}, nil)
+
+			mockClient.EXPECT().
+				Send(gomock.Any()).
+				Do(func(req http.Request) {
+					parsedURL, err := url.Parse(req.URL)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(parsedURL.Path).To(Equal("/lookup"))
+					Expect(parsedURL.Query().Get("country")).To(Equal("US"))
+					Expect(parsedURL.Query().Get("entity")).To(Equal("xrosSoftware"))
+					Expect(parsedURL.Query().Get("id")).To(Equal("200,100"))
+				}).
+				Return(http.Result[searchResult]{
+					StatusCode: 200,
+					Data: searchResult{
+						Count: 2,
+						Results: []App{
+							{ID: 100, BundleID: "hydrated.one", Name: "Hydrated One", Version: "1.0"},
+							{ID: 200, BundleID: "hydrated.two", Name: "Hydrated Two", Version: "2.0"},
+						},
+					},
+				}, nil)
+		})
+
+		It("filters native results, applies the limit, hydrates metadata, and preserves storefront order", func() {
+			out, err := as.Search(SearchInput{
+				Account:  Account{StoreFront: "143441"},
+				Term:     "spatial notes",
+				Limit:    2,
+				Platform: PlatformVisionOS,
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.Count).To(Equal(2))
+			Expect(out.Results).To(Equal([]App{
+				{ID: 200, BundleID: "hydrated.two", Name: "Hydrated Two", Version: "2.0"},
+				{ID: 100, BundleID: "hydrated.one", Name: "Hydrated One", Version: "1.0"},
+			}))
 		})
 	})
 

--- a/pkg/appstore/appstore_storefront.go
+++ b/pkg/appstore/appstore_storefront.go
@@ -1,0 +1,255 @@
+package appstore
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const (
+	serializedServerDataID   = "serialized-server-data"
+	maxVisionOSSearchResults = 12
+)
+
+type storefrontSearchPage struct {
+	Data []struct {
+		Data struct {
+			Shelves []struct {
+				Items []json.RawMessage `json:"items,omitempty"`
+			} `json:"shelves,omitempty"`
+		} `json:"data,omitempty"`
+	} `json:"data,omitempty"`
+}
+
+type storefrontSearchItem struct {
+	Kind   string          `json:"$kind,omitempty"`
+	Lockup json.RawMessage `json:"lockup,omitempty"`
+}
+
+type storefrontAppLockup struct {
+	AdamID   string `json:"adamId,omitempty"`
+	BundleID string `json:"bundleId,omitempty"`
+	Title    string `json:"title,omitempty"`
+}
+
+func serializedServerData(body []byte) ([]byte, error) {
+	markerIndex := bytes.Index(body, []byte(`id="`+serializedServerDataID+`"`))
+	if markerIndex == -1 {
+		markerIndex = bytes.Index(body, []byte(`id='`+serializedServerDataID+`'`))
+	}
+
+	if markerIndex == -1 {
+		return nil, errors.New("serialized server data was not found")
+	}
+
+	scriptStart := bytes.LastIndex(body[:markerIndex], []byte("<script"))
+	if scriptStart == -1 {
+		return nil, errors.New("serialized server data script was not found")
+	}
+
+	contentOffset := bytes.IndexByte(body[markerIndex:], '>')
+	if contentOffset == -1 {
+		return nil, errors.New("serialized server data script is malformed")
+	}
+
+	contentStart := markerIndex + contentOffset + 1
+
+	contentEndOffset := bytes.Index(body[contentStart:], []byte("</script>"))
+	if contentEndOffset == -1 {
+		return nil, errors.New("serialized server data script is not closed")
+	}
+
+	return bytes.TrimSpace(body[contentStart : contentStart+contentEndOffset]), nil
+}
+
+func storefrontVisionApps(body []byte, limit int64) ([]App, error) {
+	data, err := serializedServerData(body)
+	if err != nil {
+		return nil, err
+	}
+
+	var page storefrontSearchPage
+	if err := json.Unmarshal(data, &page); err != nil {
+		return nil, fmt.Errorf("failed to decode serialized server data: %w", err)
+	}
+
+	if limit <= 0 {
+		return []App{}, nil
+	}
+
+	limit = min(limit, maxVisionOSSearchResults)
+
+	apps := make([]App, 0, int(limit))
+	seen := make(map[int64]struct{})
+
+	for _, pageData := range page.Data {
+		for _, shelf := range pageData.Data.Shelves {
+			for _, rawItem := range shelf.Items {
+				var item storefrontSearchItem
+				if err := json.Unmarshal(rawItem, &item); err != nil || item.Kind != "AppSearchResult" {
+					continue
+				}
+
+				var lockup storefrontAppLockup
+				if err := json.Unmarshal(item.Lockup, &lockup); err != nil {
+					continue
+				}
+
+				appID, err := strconv.ParseInt(lockup.AdamID, 10, 64)
+				if err != nil || appID == 0 {
+					continue
+				}
+
+				if _, ok := seen[appID]; ok {
+					continue
+				}
+
+				if !containsVisionPurchaseConfiguration(rawItem, appID) {
+					continue
+				}
+
+				seen[appID] = struct{}{}
+
+				apps = append(apps, App{
+					ID:       appID,
+					BundleID: lockup.BundleID,
+					Name:     lockup.Title,
+				})
+
+				if int64(len(apps)) == limit {
+					return apps, nil
+				}
+			}
+		}
+	}
+
+	return apps, nil
+}
+
+func containsVisionPurchaseConfiguration(data []byte, appID int64) bool {
+	var value interface{}
+	if err := json.Unmarshal(data, &value); err != nil {
+		return false
+	}
+
+	_, found := findVisionExternalVersionID(value, appID)
+
+	return found
+}
+
+func visionExternalVersionID(body []byte, appID int64) (string, error) {
+	data, err := serializedServerData(body)
+	if err != nil {
+		return "", err
+	}
+
+	var value interface{}
+	if err := json.Unmarshal(data, &value); err != nil {
+		return "", fmt.Errorf("failed to decode serialized server data: %w", err)
+	}
+
+	externalVersionID, found := findVisionExternalVersionID(value, appID)
+	if !found {
+		return "", errors.New("visionOS purchase configuration was not found")
+	}
+
+	if externalVersionID == "" {
+		return "", errors.New("visionOS purchase configuration has no external version id")
+	}
+
+	return externalVersionID, nil
+}
+
+func findVisionExternalVersionID(value interface{}, appID int64) (string, bool) {
+	matched := false
+
+	switch typedValue := value.(type) {
+	case []interface{}:
+		for _, item := range typedValue {
+			if externalVersionID, found := findVisionExternalVersionID(item, appID); found {
+				if externalVersionID != "" {
+					return externalVersionID, true
+				}
+
+				matched = true
+			}
+		}
+	case map[string]interface{}:
+		if configuration, ok := typedValue["purchaseConfiguration"].(map[string]interface{}); ok {
+			if externalVersionID, found := externalVersionIDFromVisionConfiguration(configuration, appID); found {
+				if externalVersionID != "" {
+					return externalVersionID, true
+				}
+
+				matched = true
+			}
+		}
+
+		for _, child := range typedValue {
+			if externalVersionID, found := findVisionExternalVersionID(child, appID); found {
+				if externalVersionID != "" {
+					return externalVersionID, true
+				}
+
+				matched = true
+			}
+		}
+	}
+
+	return "", matched
+}
+
+func externalVersionIDFromVisionConfiguration(configuration map[string]interface{}, appID int64) (string, bool) {
+	if configuration["metricsPlatformDisplayStyle"] != "vision" {
+		return "", false
+	}
+
+	platforms, ok := configuration["appPlatforms"].([]interface{})
+	if !ok {
+		return "", false
+	}
+
+	isVisionApp := false
+
+	for _, platform := range platforms {
+		if platform == "vision" {
+			isVisionApp = true
+
+			break
+		}
+	}
+
+	if !isVisionApp {
+		return "", false
+	}
+
+	buyParams, ok := configuration["buyParams"].(string)
+	if !ok || buyParams == "" {
+		return "", false
+	}
+
+	values, err := url.ParseQuery(buyParams)
+	if err != nil || values.Get("salableAdamId") != strconv.FormatInt(appID, 10) {
+		return "", false
+	}
+
+	return values.Get("appExtVrsId"), true
+}
+
+func visionSearchURL(term, countryCode string) string {
+	params := url.Values{}
+	params.Set("term", term)
+
+	return fmt.Sprintf("https://apps.apple.com/%s/vision/search?%s", strings.ToLower(countryCode), params.Encode())
+}
+
+func visionProductURL(appID int64, countryCode string) string {
+	params := url.Values{}
+	params.Set("platform", "vision")
+
+	return fmt.Sprintf("https://apps.apple.com/%s/app/id%d?%s", strings.ToLower(countryCode), appID, params.Encode())
+}

--- a/pkg/appstore/appstore_storefront_test.go
+++ b/pkg/appstore/appstore_storefront_test.go
@@ -1,0 +1,155 @@
+package appstore
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func storefrontSearchItemFixture(kind, adamID, platform, salableAdamID, externalVersionID string) string {
+	return fmt.Sprintf(`{
+		"$kind":%q,
+		"lockup":{"adamId":%q,"bundleId":%q,"title":%q},
+		"offer":{"purchaseConfiguration":{
+			"metricsPlatformDisplayStyle":%q,
+			"appPlatforms":[%q],
+			"buyParams":%q
+		}}
+	}`,
+		kind,
+		adamID,
+		"bundle."+adamID,
+		"App "+adamID,
+		platform,
+		platform,
+		"salableAdamId="+salableAdamID+"&appExtVrsId="+externalVersionID,
+	)
+}
+
+func storefrontPageFixture(items ...string) []byte {
+	return []byte(`<html><head></head><body><script data-test="value" id='serialized-server-data' type="application/json">{
+		"data":[{"data":{"shelves":[{"items":[` +
+		strings.Join(items, ",") +
+		`] }]}}]}
+	</script></body></html>`)
+}
+
+var _ = Describe("App Store storefront data", func() {
+	Describe("storefrontVisionApps", func() {
+		It("keeps unique native visionOS apps in storefront order and applies the limit", func() {
+			body := storefrontPageFixture(
+				storefrontSearchItemFixture("EditorialItem", "900", "vision", "900", "9000"),
+				storefrontSearchItemFixture("AppSearchResult", "200", "vision", "200", "2000"),
+				storefrontSearchItemFixture("AppSearchResult", "300", "ios", "300", "3000"),
+				storefrontSearchItemFixture("AppSearchResult", "not-an-id", "vision", "0", "4000"),
+				storefrontSearchItemFixture("AppSearchResult", "200", "vision", "200", "2000"),
+				storefrontSearchItemFixture("AppSearchResult", "100", "vision", "999", "1000"),
+				storefrontSearchItemFixture("AppSearchResult", "100", "vision", "100", "1000"),
+				storefrontSearchItemFixture("AppSearchResult", "400", "vision", "400", "4000"),
+			)
+
+			apps, err := storefrontVisionApps(body, 2)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(apps).To(Equal([]App{
+				{ID: 200, BundleID: "bundle.200", Name: "App 200"},
+				{ID: 100, BundleID: "bundle.100", Name: "App 100"},
+			}))
+		})
+
+		It("returns an empty slice for a zero limit", func() {
+			body := storefrontPageFixture(
+				storefrontSearchItemFixture("AppSearchResult", "100", "vision", "100", "1000"),
+			)
+
+			apps, err := storefrontVisionApps(body, 0)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(apps).To(BeEmpty())
+		})
+
+		It("caps oversized limits to the storefront result maximum", func() {
+			items := make([]string, 0, maxVisionOSSearchResults+1)
+			for index := 1; index <= maxVisionOSSearchResults+1; index++ {
+				appID := fmt.Sprintf("%d", index)
+				items = append(items, storefrontSearchItemFixture("AppSearchResult", appID, "vision", appID, appID+"0"))
+			}
+
+			apps, err := storefrontVisionApps(storefrontPageFixture(items...), 1<<62)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(apps).To(HaveLen(maxVisionOSSearchResults))
+		})
+
+		It("returns an error when serialized data is absent", func() {
+			_, err := storefrontVisionApps([]byte("<html></html>"), 5)
+
+			Expect(err).To(MatchError("serialized server data was not found"))
+		})
+
+		It("returns an error when serialized data is invalid JSON", func() {
+			_, err := storefrontVisionApps([]byte(`<script id="serialized-server-data">not-json</script>`), 5)
+
+			Expect(err).To(MatchError(ContainSubstring("failed to decode serialized server data")))
+		})
+	})
+
+	Describe("visionExternalVersionID", func() {
+		It("selects the matching vision purchase configuration", func() {
+			body := []byte(`<script id="serialized-server-data">{
+				"data":[
+					{"purchaseConfiguration":{"metricsPlatformDisplayStyle":"ios","appPlatforms":["iphone"],"buyParams":"salableAdamId=100&appExtVrsId=ios-version"}},
+					{"nested":{"purchaseConfiguration":{"metricsPlatformDisplayStyle":"vision","appPlatforms":["vision"],"buyParams":"salableAdamId=999&appExtVrsId=wrong-app"}}},
+					{"nested":{"purchaseConfiguration":{"metricsPlatformDisplayStyle":"vision","appPlatforms":["vision"],"buyParams":"salableAdamId=100&appExtVrsId=vision-version"}}}
+				]}
+			</script>`)
+
+			externalVersionID, err := visionExternalVersionID(body, 100)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(externalVersionID).To(Equal("vision-version"))
+		})
+
+		It("returns an error when no matching vision purchase configuration exists", func() {
+			body := []byte(`<script id="serialized-server-data">{
+				"purchaseConfiguration":{"metricsPlatformDisplayStyle":"ios","appPlatforms":["iphone"],"buyParams":"salableAdamId=100&appExtVrsId=ios-version"}
+			}</script>`)
+
+			_, err := visionExternalVersionID(body, 100)
+
+			Expect(err).To(MatchError("visionOS purchase configuration was not found"))
+		})
+
+		It("distinguishes a matching configuration with no external version id", func() {
+			body := []byte(`<script id="serialized-server-data">{
+				"purchaseConfiguration":{"metricsPlatformDisplayStyle":"vision","appPlatforms":["vision"],"buyParams":"salableAdamId=100"}
+			}</script>`)
+
+			_, err := visionExternalVersionID(body, 100)
+
+			Expect(err).To(MatchError("visionOS purchase configuration has no external version id"))
+		})
+
+		It("prefers a populated matching configuration over an empty duplicate", func() {
+			body := []byte(`<script id="serialized-server-data">{
+				"data":[
+					{"purchaseConfiguration":{"metricsPlatformDisplayStyle":"vision","appPlatforms":["vision"],"buyParams":"salableAdamId=100"}},
+					{"purchaseConfiguration":{"metricsPlatformDisplayStyle":"vision","appPlatforms":["vision"],"buyParams":"salableAdamId=100&appExtVrsId=vision-version"}}
+				]
+			}</script>`)
+
+			externalVersionID, err := visionExternalVersionID(body, 100)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(externalVersionID).To(Equal("vision-version"))
+		})
+
+		It("returns an error when the serialized script is not closed", func() {
+			_, err := visionExternalVersionID([]byte(`<script id="serialized-server-data">{}`), 100)
+
+			Expect(err).To(MatchError("serialized server data script is not closed"))
+		})
+	})
+})

--- a/pkg/appstore/platform.go
+++ b/pkg/appstore/platform.go
@@ -1,25 +1,31 @@
 package appstore
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type Platform string
 
 const (
-	PlatformIPhone  Platform = "iphone"
-	PlatformIPad    Platform = "ipad"
-	PlatformAppleTV Platform = "appletv"
+	PlatformIPhone   Platform = "iphone"
+	PlatformIPad     Platform = "ipad"
+	PlatformAppleTV  Platform = "appletv"
+	PlatformVisionOS Platform = "visionos"
 )
 
 func ParsePlatform(value string) (Platform, error) {
-	switch value {
+	switch strings.ToLower(value) {
 	case "":
 		return "", nil
-	case "iphone", "iPhone", "ios", "iOS":
+	case "iphone", "ios":
 		return PlatformIPhone, nil
-	case "ipad", "iPad":
+	case "ipad", "ipados":
 		return PlatformIPad, nil
-	case "appletv", "AppleTV", "apple-tv", "tvos", "tvOS":
+	case "appletv", "apple-tv", "tvos":
 		return PlatformAppleTV, nil
+	case "vision", "visionos", "visionpro", "xros", "realitydevice":
+		return PlatformVisionOS, nil
 	default:
 		return "", fmt.Errorf("invalid platform %q", value)
 	}
@@ -35,6 +41,8 @@ func (p Platform) lookupEntity() (string, error) {
 		return "iPadSoftware", nil
 	case PlatformAppleTV:
 		return "tvSoftware", nil
+	case PlatformVisionOS:
+		return "xrosSoftware", nil
 	default:
 		return "", fmt.Errorf("invalid platform %q", p)
 	}
@@ -50,6 +58,8 @@ func (p Platform) searchEntity() (string, error) {
 		return "iPadSoftware", nil
 	case PlatformAppleTV:
 		return "software,tvSoftware", nil
+	case PlatformVisionOS:
+		return "xrosSoftware", nil
 	default:
 		return "", fmt.Errorf("invalid platform %q", p)
 	}
@@ -61,6 +71,8 @@ func (p Platform) metadataPlatform() (string, error) {
 		return "enterprisestore", nil
 	case PlatformAppleTV:
 		return "atv9", nil
+	case PlatformVisionOS:
+		return "realityDevice", nil
 	default:
 		return "", fmt.Errorf("invalid platform %q", p)
 	}

--- a/pkg/appstore/platform_test.go
+++ b/pkg/appstore/platform_test.go
@@ -16,12 +16,67 @@ var _ = Describe("Platform", func() {
 		Entry("iPhone", "iphone", PlatformIPhone),
 		Entry("iOS", "ios", PlatformIPhone),
 		Entry("iPad", "ipad", PlatformIPad),
+		Entry("iPadOS", "iPadOS", PlatformIPad),
 		Entry("AppleTV", "appletv", PlatformAppleTV),
 		Entry("tvOS", "tvos", PlatformAppleTV),
+		Entry("visionOS", "visionOS", PlatformVisionOS),
+		Entry("Vision Pro", "visionpro", PlatformVisionOS),
+		Entry("xrOS", "xrOS", PlatformVisionOS),
+		Entry("realityDevice", "realityDevice", PlatformVisionOS),
+	)
+
+	DescribeTable("maps platforms to lookup entities",
+		func(platform Platform, expected string) {
+			entity, err := platform.lookupEntity()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(entity).To(Equal(expected))
+		},
+		Entry("default", Platform(""), "software,iPadSoftware"),
+		Entry("iPhone", PlatformIPhone, "software"),
+		Entry("iPad", PlatformIPad, "iPadSoftware"),
+		Entry("Apple TV", PlatformAppleTV, "tvSoftware"),
+		Entry("visionOS", PlatformVisionOS, "xrosSoftware"),
+	)
+
+	DescribeTable("maps platforms to search entities",
+		func(platform Platform, expected string) {
+			entity, err := platform.searchEntity()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(entity).To(Equal(expected))
+		},
+		Entry("default", Platform(""), "software,iPadSoftware"),
+		Entry("iPhone", PlatformIPhone, "software"),
+		Entry("iPad", PlatformIPad, "iPadSoftware"),
+		Entry("Apple TV", PlatformAppleTV, "software,tvSoftware"),
+		Entry("visionOS", PlatformVisionOS, "xrosSoftware"),
+	)
+
+	DescribeTable("maps platforms to metadata platforms",
+		func(platform Platform, expected string) {
+			metadataPlatform, err := platform.metadataPlatform()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metadataPlatform).To(Equal(expected))
+		},
+		Entry("iPhone", PlatformIPhone, "enterprisestore"),
+		Entry("iPad", PlatformIPad, "enterprisestore"),
+		Entry("Apple TV", PlatformAppleTV, "atv9"),
+		Entry("visionOS", PlatformVisionOS, "realityDevice"),
 	)
 
 	It("returns an error for invalid platforms", func() {
 		_, err := ParsePlatform("watch")
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("returns errors when an unknown platform is mapped", func() {
+		platform := Platform("watch")
+
+		_, lookupErr := platform.lookupEntity()
+		_, searchErr := platform.searchEntity()
+		_, metadataErr := platform.metadataPlatform()
+
+		Expect(lookupErr).To(HaveOccurred())
+		Expect(searchErr).To(HaveOccurred())
+		Expect(metadataErr).To(HaveOccurred())
 	})
 })


### PR DESCRIPTION
## Summary

- add visionOS support to the existing `--platform` filter
- accept iOS, iPadOS, tvOS, and visionOS platform aliases
- search native visionOS apps through Apple’s vision storefront
- resolve visionOS-specific external version IDs for universal apps
- validate downloaded visionOS packages using the top-level `XROS` platform declaration
- update CLI help, documentation, and regression coverage

visionOS storefront searches return up to 12 results.
