### PR TITLE
Add macOS search and download support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Release](https://img.shields.io/github/release/majd/ipatool.svg?label=Release)](https://GitHub.com/majd/ipatool/releases/)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/majd/ipatool/blob/main/LICENSE)
 
-`ipatool` is a command line tool that allows you to search for iOS, iPadOS, tvOS, and visionOS apps on the [App Store](https://apps.apple.com) and download a copy of the app package, known as an _ipa_ file.
+`ipatool` is a command line tool that allows you to search for iOS, iPadOS, tvOS, visionOS, and macOS apps on the [App Store](https://apps.apple.com), and download `.ipa` or macOS `.pkg` app packages.
 
 ![Demo](./resources/demo.gif)
 
@@ -65,7 +65,7 @@ Use "ipatool auth [command] --help" for more information about a command.
 To search for apps on the App Store, use the `search` command.
 
 ```
-Search for iOS, iPadOS, tvOS, and visionOS apps available on the App Store
+Search for iOS, iPadOS, tvOS, visionOS, and macOS apps available on the App Store
 
 Usage:
   ipatool search <term> [flags]
@@ -73,7 +73,7 @@ Usage:
 Flags:
   -h, --help              help for search
   -l, --limit int         maximum amount of search results to retrieve; visionOS supports up to 12 (default 5)
-      --platform string   Platform to search: iphone (iOS), ipad (iPadOS), appletv (tvOS), or visionos
+      --platform string   Platform to search: iphone (iOS), ipad (iPadOS), appletv (tvOS), visionos, or macos
 
 Global Flags:
       --format format     sets output format for command; can be 'text', 'json' (default text)
@@ -90,8 +90,9 @@ Usage:
   ipatool purchase [flags]
 
 Flags:
-  -b, --bundle-identifier string   Bundle identifier of the target iOS app (required)
+  -b, --bundle-identifier string   Bundle identifier of the target app (required)
   -h, --help                       help for purchase
+      --platform string            Platform to purchase for: iphone (iOS), ipad (iPadOS), appletv (tvOS), visionos, or macos
 
 Global Flags:
       --format format     sets output format for command; can be 'text', 'json' (default text)
@@ -139,10 +140,10 @@ Global Flags:
       --verbose                      enables verbose logs
 ```
 
-To download a copy of the ipa file, use the `download` command.
+To download an app package, use the `download` command.
 
 ```
-Download (encrypted) iOS, iPadOS, tvOS, and visionOS app packages from the App Store
+Download iOS, iPadOS, tvOS, visionOS, and macOS app packages from the App Store
 
 Usage:
   ipatool download [flags]
@@ -153,7 +154,7 @@ Flags:
       --external-version-id string   External version identifier of the target app (defaults to latest version when not specified)
   -h, --help                         help for download
   -o, --output string                The destination path of the downloaded app package
-      --platform string              Platform to download for: iphone (iOS), ipad (iPadOS), appletv (tvOS), or visionos
+      --platform string              Platform to download for: iphone (iOS), ipad (iPadOS), appletv (tvOS), visionos, or macos
       --purchase                     Obtain a license for the app if needed
 
 Global Flags:

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -13,6 +13,11 @@ import (
 
 // nolint:wrapcheck
 func downloadCmd() *cobra.Command {
+	return downloadCmdWithAppStore(func() appstore.AppStore { return dependencies.AppStore })
+}
+
+//nolint:wrapcheck
+func downloadCmdWithAppStore(appStore func() appstore.AppStore) *cobra.Command {
 	var (
 		acquireLicense    bool
 		outputPath        string
@@ -24,18 +29,25 @@ func downloadCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "download",
-		Short: "Download (encrypted) iOS, iPadOS, tvOS, and visionOS app packages from the App Store",
+		Short: "Download iOS, iPadOS, tvOS, visionOS, and macOS app packages from the App Store",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if appID == 0 && bundleID == "" {
 				return errors.New("either the app ID or the bundle identifier must be specified")
 			}
 
+			platform, err := appstore.ParsePlatform(platformValue)
+			if err != nil {
+				return err
+			}
+
 			var lastErr error
 			var acc appstore.Account
+			purchaseRequired := false
 			purchased := false
 
 			return retry.Do(func() error {
-				infoResult, err := dependencies.AppStore.AccountInfo()
+				store := appStore()
+				infoResult, err := store.AccountInfo()
 				if err != nil {
 					return err
 				}
@@ -43,7 +55,7 @@ func downloadCmd() *cobra.Command {
 				acc = infoResult.Account
 
 				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
-					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{
+					loginResult, err := store.Login(appstore.LoginInput{
 						Email:    acc.Email,
 						Password: acc.Password,
 					})
@@ -55,13 +67,9 @@ func downloadCmd() *cobra.Command {
 				}
 
 				app := appstore.App{ID: appID}
-				platform, err := appstore.ParsePlatform(platformValue)
-				if err != nil {
-					return err
-				}
 
 				if bundleID != "" {
-					lookupResult, err := dependencies.AppStore.Lookup(appstore.LookupInput{
+					lookupResult, err := store.Lookup(appstore.LookupInput{
 						Account:  acc,
 						BundleID: bundleID,
 						Platform: platform,
@@ -74,10 +82,19 @@ func downloadCmd() *cobra.Command {
 				}
 
 				if errors.Is(lastErr, appstore.ErrLicenseRequired) {
-					err := dependencies.AppStore.Purchase(appstore.PurchaseInput{Account: acc, App: app})
+					purchaseRequired = true
+				}
+
+				if purchaseRequired {
+					err := store.Purchase(appstore.PurchaseInput{
+						Account:  acc,
+						App:      app,
+						Platform: platform,
+					})
 					if err != nil && !errors.Is(err, appstore.ErrLicenseAlreadyExists) {
 						return err
 					}
+					purchaseRequired = false
 					purchased = true
 					dependencies.Logger.Verbose().
 						Bool("success", true).
@@ -103,7 +120,8 @@ func downloadCmd() *cobra.Command {
 					)
 				}
 
-				out, err := dependencies.AppStore.Download(appstore.DownloadInput{
+				out, err := store.Download(appstore.DownloadInput{
+					Context:           cmd.Context(),
 					Account:           acc,
 					App:               app,
 					OutputPath:        outputPath,
@@ -115,8 +133,7 @@ func downloadCmd() *cobra.Command {
 					return err
 				}
 
-				err = dependencies.AppStore.ReplicateSinf(appstore.ReplicateSinfInput{Sinfs: out.Sinfs, PackagePath: out.DestinationPath})
-				if err != nil {
+				if err := replicateDownloadSinf(store, platform, out); err != nil {
 					return err
 				}
 
@@ -153,8 +170,21 @@ func downloadCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&bundleID, "bundle-identifier", "b", "", "The bundle identifier of the target app (overrides the app ID)")
 	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "The destination path of the downloaded app package")
 	cmd.Flags().StringVar(&externalVersionID, "external-version-id", "", "External version identifier of the target app (defaults to latest version when not specified)")
-	cmd.Flags().StringVar(&platformValue, "platform", "", "Platform to download for: iphone (iOS), ipad (iPadOS), appletv (tvOS), or visionos")
+	cmd.Flags().StringVar(&platformValue, "platform", "", "Platform to download for: iphone (iOS), ipad (iPadOS), appletv (tvOS), visionos, or macos")
 	cmd.Flags().BoolVar(&acquireLicense, "purchase", false, "Obtain a license for the app if needed")
 
 	return cmd
+}
+
+type sinfReplicator interface {
+	ReplicateSinf(input appstore.ReplicateSinfInput) error
+}
+
+//nolint:wrapcheck
+func replicateDownloadSinf(store sinfReplicator, platform appstore.Platform, out appstore.DownloadOutput) error {
+	if platform == appstore.PlatformMacOS {
+		return nil
+	}
+
+	return store.ReplicateSinf(appstore.ReplicateSinfInput{Sinfs: out.Sinfs, PackagePath: out.DestinationPath})
 }

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -1,0 +1,172 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+
+	"github.com/majd/ipatool/v2/pkg/appstore"
+	"github.com/majd/ipatool/v2/pkg/log"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Download command", func() {
+	It("exposes macOS in platform help", func() {
+		cmd := downloadCmd()
+		Expect(cmd.Flag("platform").Usage).To(ContainSubstring("macos"))
+	})
+
+	It("skips sinf replication for macOS packages", func() {
+		replicator := &fakeSinfReplicator{}
+		err := replicateDownloadSinf(replicator, appstore.PlatformMacOS, appstore.DownloadOutput{
+			DestinationPath: "app.pkg",
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(replicator.called).To(BeFalse())
+	})
+
+	It("replicates sinf for non-macOS packages", func() {
+		replicator := &fakeSinfReplicator{}
+		out := appstore.DownloadOutput{
+			DestinationPath: "app.ipa",
+			Sinfs:           []appstore.Sinf{{Data: []byte("sinf")}},
+		}
+
+		err := replicateDownloadSinf(replicator, appstore.PlatformIPhone, out)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(replicator.called).To(BeTrue())
+		Expect(replicator.input).To(Equal(appstore.ReplicateSinfInput{
+			PackagePath: out.DestinationPath,
+			Sinfs:       out.Sinfs,
+		}))
+	})
+
+	It("returns sinf replication errors for non-macOS packages", func() {
+		replicator := &fakeSinfReplicator{err: errors.New("replication failed")}
+		err := replicateDownloadSinf(replicator, appstore.PlatformIPhone, appstore.DownloadOutput{})
+		Expect(err).To(MatchError("replication failed"))
+	})
+
+	It("propagates macOS when automatic purchase retries the download", func() {
+		store := &fakeDownloadAppStore{downloadErrors: []error{appstore.ErrLicenseRequired, nil}}
+		previousDependencies := dependencies
+		DeferCleanup(func() { dependencies = previousDependencies })
+		dependencies.Logger = log.NewLogger(log.Args{})
+
+		cmd := downloadCmdWithAppStore(func() appstore.AppStore { return store })
+		cmd.SetArgs([]string{"--app-id", "42", "--platform", "macos", "--purchase"})
+		cmd.SetContext(context.WithValue(context.Background(), interactiveKey, false))
+
+		Expect(cmd.Execute()).To(Succeed())
+		Expect(store.purchaseInputs).To(HaveLen(1))
+		Expect(store.purchaseInputs[0].Platform).To(Equal(appstore.PlatformMacOS))
+		Expect(store.purchaseInputs[0].App).To(Equal(appstore.App{ID: 42}))
+		Expect(store.downloadInputs).To(HaveLen(2))
+		Expect(store.downloadInputs[0].Platform).To(Equal(appstore.PlatformMacOS))
+		Expect(store.downloadInputs[1].Platform).To(Equal(appstore.PlatformMacOS))
+	})
+
+	It("retains the pending automatic purchase after refreshing authentication", func() {
+		store := &fakeDownloadAppStore{
+			downloadErrors: []error{appstore.ErrLicenseRequired, nil},
+			purchaseErrors: []error{appstore.ErrPasswordTokenExpired, nil},
+		}
+		previousDependencies := dependencies
+		DeferCleanup(func() { dependencies = previousDependencies })
+		dependencies.Logger = log.NewLogger(log.Args{})
+
+		cmd := downloadCmdWithAppStore(func() appstore.AppStore { return store })
+		cmd.SetArgs([]string{"--app-id", "42", "--platform", "macos", "--purchase"})
+		cmd.SetContext(context.WithValue(context.Background(), interactiveKey, false))
+
+		Expect(cmd.Execute()).To(Succeed())
+		Expect(store.loginInputs).To(HaveLen(1))
+		Expect(store.purchaseInputs).To(HaveLen(2))
+		Expect(store.purchaseInputs[0].Platform).To(Equal(appstore.PlatformMacOS))
+		Expect(store.purchaseInputs[1].Platform).To(Equal(appstore.PlatformMacOS))
+		Expect(store.downloadInputs).To(HaveLen(2))
+	})
+})
+
+type fakeSinfReplicator struct {
+	called bool
+	input  appstore.ReplicateSinfInput
+	err    error
+}
+
+func (f *fakeSinfReplicator) ReplicateSinf(input appstore.ReplicateSinfInput) error {
+	f.called = true
+	f.input = input
+
+	return f.err
+}
+
+type fakeDownloadAppStore struct {
+	downloadErrors []error
+	downloadInputs []appstore.DownloadInput
+	loginInputs    []appstore.LoginInput
+	purchaseErrors []error
+	purchaseInputs []appstore.PurchaseInput
+}
+
+func (f *fakeDownloadAppStore) Login(input appstore.LoginInput) (appstore.LoginOutput, error) {
+	f.loginInputs = append(f.loginInputs, input)
+
+	return appstore.LoginOutput{Account: appstore.Account{StoreFront: "143441"}}, nil
+}
+
+func (*fakeDownloadAppStore) AccountInfo() (appstore.AccountInfoOutput, error) {
+	return appstore.AccountInfoOutput{Account: appstore.Account{StoreFront: "143441"}}, nil
+}
+
+func (*fakeDownloadAppStore) Revoke() error { return nil }
+
+func (*fakeDownloadAppStore) Lookup(input appstore.LookupInput) (appstore.LookupOutput, error) {
+	return appstore.LookupOutput{}, nil
+}
+
+func (*fakeDownloadAppStore) Search(input appstore.SearchInput) (appstore.SearchOutput, error) {
+	return appstore.SearchOutput{}, nil
+}
+
+func (*fakeDownloadAppStore) OwnedApps(input appstore.OwnedAppsInput) (appstore.OwnedAppsOutput, error) {
+	return appstore.OwnedAppsOutput{}, nil
+}
+
+func (f *fakeDownloadAppStore) Purchase(input appstore.PurchaseInput) error {
+	f.purchaseInputs = append(f.purchaseInputs, input)
+	index := len(f.purchaseInputs) - 1
+
+	if index < len(f.purchaseErrors) && f.purchaseErrors[index] != nil {
+		return f.purchaseErrors[index]
+	}
+
+	return nil
+}
+
+func (f *fakeDownloadAppStore) Download(input appstore.DownloadInput) (appstore.DownloadOutput, error) {
+	f.downloadInputs = append(f.downloadInputs, input)
+	index := len(f.downloadInputs) - 1
+
+	if index < len(f.downloadErrors) && f.downloadErrors[index] != nil {
+		return appstore.DownloadOutput{}, f.downloadErrors[index]
+	}
+
+	return appstore.DownloadOutput{DestinationPath: "app.pkg"}, nil
+}
+
+func (*fakeDownloadAppStore) ReplicateSinf(input appstore.ReplicateSinfInput) error { return nil }
+
+func (*fakeDownloadAppStore) ListVersions(input appstore.ListVersionsInput) (appstore.ListVersionsOutput, error) {
+	return appstore.ListVersionsOutput{}, nil
+}
+
+func (*fakeDownloadAppStore) GetVersionMetadata(input appstore.GetVersionMetadataInput) (appstore.GetVersionMetadataOutput, error) {
+	return appstore.GetVersionMetadataOutput{}, nil
+}
+
+func (*fakeDownloadAppStore) Bag(input appstore.BagInput) (appstore.BagOutput, error) {
+	return appstore.BagOutput{}, nil
+}

--- a/cmd/purchase.go
+++ b/cmd/purchase.go
@@ -11,17 +11,31 @@ import (
 
 // nolint:wrapcheck
 func purchaseCmd() *cobra.Command {
-	var bundleID string
+	return purchaseCmdWithAppStore(func() appstore.AppStore { return dependencies.AppStore })
+}
+
+//nolint:wrapcheck
+func purchaseCmdWithAppStore(appStore func() appstore.AppStore) *cobra.Command {
+	var (
+		bundleID      string
+		platformValue string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "purchase",
 		Short: "Obtain a license for the app from the App Store",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			platform, err := appstore.ParsePlatform(platformValue)
+			if err != nil {
+				return err
+			}
+
 			var lastErr error
 			var acc appstore.Account
 
 			return retry.Do(func() error {
-				infoResult, err := dependencies.AppStore.AccountInfo()
+				store := appStore()
+				infoResult, err := store.AccountInfo()
 				if err != nil {
 					return err
 				}
@@ -29,7 +43,7 @@ func purchaseCmd() *cobra.Command {
 				acc = infoResult.Account
 
 				if errors.Is(lastErr, appstore.ErrPasswordTokenExpired) {
-					loginResult, err := dependencies.AppStore.Login(appstore.LoginInput{
+					loginResult, err := store.Login(appstore.LoginInput{
 						Email:    acc.Email,
 						Password: acc.Password,
 					})
@@ -40,12 +54,20 @@ func purchaseCmd() *cobra.Command {
 					acc = loginResult.Account
 				}
 
-				lookupResult, err := dependencies.AppStore.Lookup(appstore.LookupInput{Account: acc, BundleID: bundleID})
+				lookupResult, err := store.Lookup(appstore.LookupInput{
+					Account:  acc,
+					BundleID: bundleID,
+					Platform: platform,
+				})
 				if err != nil {
 					return err
 				}
 
-				err = dependencies.AppStore.Purchase(appstore.PurchaseInput{Account: acc, App: lookupResult.App})
+				err = store.Purchase(appstore.PurchaseInput{
+					Account:  acc,
+					App:      lookupResult.App,
+					Platform: platform,
+				})
 				if err != nil && !errors.Is(err, appstore.ErrLicenseAlreadyExists) {
 					return err
 				}
@@ -70,7 +92,8 @@ func purchaseCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&bundleID, "bundle-identifier", "b", "", "Bundle identifier of the target iOS app (required)")
+	cmd.Flags().StringVarP(&bundleID, "bundle-identifier", "b", "", "Bundle identifier of the target app (required)")
+	cmd.Flags().StringVar(&platformValue, "platform", "", "Platform to purchase for: iphone (iOS), ipad (iPadOS), appletv (tvOS), visionos, or macos")
 	_ = cmd.MarkFlagRequired("bundle-identifier")
 
 	return cmd

--- a/cmd/purchase_test.go
+++ b/cmd/purchase_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"github.com/majd/ipatool/v2/pkg/appstore"
+	"github.com/majd/ipatool/v2/pkg/log"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Purchase command", func() {
+	It("accepts a platform flag with macOS help", func() {
+		cmd := purchaseCmd()
+		platform, err := cmd.Flags().GetString("platform")
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(platform).To(BeEmpty())
+		Expect(cmd.Flag("platform").Usage).To(ContainSubstring("macos"))
+	})
+
+	It("propagates macOS to lookup and purchase", func() {
+		store := &fakePurchaseAppStore{}
+		previousDependencies := dependencies
+		DeferCleanup(func() { dependencies = previousDependencies })
+		dependencies.Logger = log.NewLogger(log.Args{})
+
+		cmd := purchaseCmdWithAppStore(func() appstore.AppStore { return store })
+		cmd.SetArgs([]string{"--bundle-identifier", "com.example.mac", "--platform", "macos"})
+
+		Expect(cmd.Execute()).To(Succeed())
+		Expect(store.lookupInput.BundleID).To(Equal("com.example.mac"))
+		Expect(store.lookupInput.Platform).To(Equal(appstore.PlatformMacOS))
+		Expect(store.purchaseInput.Platform).To(Equal(appstore.PlatformMacOS))
+		Expect(store.purchaseInput.App).To(Equal(appstore.App{ID: 42, BundleID: "com.example.mac"}))
+	})
+})
+
+type fakePurchaseAppStore struct {
+	lookupInput   appstore.LookupInput
+	purchaseInput appstore.PurchaseInput
+}
+
+func (*fakePurchaseAppStore) Login(input appstore.LoginInput) (appstore.LoginOutput, error) {
+	return appstore.LoginOutput{}, nil
+}
+
+func (*fakePurchaseAppStore) AccountInfo() (appstore.AccountInfoOutput, error) {
+	return appstore.AccountInfoOutput{Account: appstore.Account{StoreFront: "143441"}}, nil
+}
+
+func (*fakePurchaseAppStore) Revoke() error { return nil }
+
+func (f *fakePurchaseAppStore) Lookup(input appstore.LookupInput) (appstore.LookupOutput, error) {
+	f.lookupInput = input
+
+	return appstore.LookupOutput{App: appstore.App{ID: 42, BundleID: input.BundleID}}, nil
+}
+
+func (*fakePurchaseAppStore) Search(input appstore.SearchInput) (appstore.SearchOutput, error) {
+	return appstore.SearchOutput{}, nil
+}
+
+func (*fakePurchaseAppStore) OwnedApps(input appstore.OwnedAppsInput) (appstore.OwnedAppsOutput, error) {
+	return appstore.OwnedAppsOutput{}, nil
+}
+
+func (f *fakePurchaseAppStore) Purchase(input appstore.PurchaseInput) error {
+	f.purchaseInput = input
+
+	return nil
+}
+
+func (*fakePurchaseAppStore) Download(input appstore.DownloadInput) (appstore.DownloadOutput, error) {
+	return appstore.DownloadOutput{}, nil
+}
+
+func (*fakePurchaseAppStore) ReplicateSinf(input appstore.ReplicateSinfInput) error { return nil }
+
+func (*fakePurchaseAppStore) ListVersions(input appstore.ListVersionsInput) (appstore.ListVersionsOutput, error) {
+	return appstore.ListVersionsOutput{}, nil
+}
+
+func (*fakePurchaseAppStore) GetVersionMetadata(input appstore.GetVersionMetadataInput) (appstore.GetVersionMetadataOutput, error) {
+	return appstore.GetVersionMetadataOutput{}, nil
+}
+
+func (*fakePurchaseAppStore) Bag(input appstore.BagInput) (appstore.BagOutput, error) {
+	return appstore.BagOutput{}, nil
+}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -14,7 +14,7 @@ func searchCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "search <term>",
-		Short: "Search for iOS, iPadOS, tvOS, and visionOS apps available on the App Store",
+		Short: "Search for iOS, iPadOS, tvOS, visionOS, and macOS apps available on the App Store",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			infoResult, err := dependencies.AppStore.AccountInfo()
@@ -47,7 +47,7 @@ func searchCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Int64VarP(&limit, "limit", "l", 5, "maximum amount of search results to retrieve; visionOS supports up to 12")
-	cmd.Flags().StringVar(&platformValue, "platform", "", "Platform to search: iphone (iOS), ipad (iPadOS), appletv (tvOS), or visionos")
+	cmd.Flags().StringVar(&platformValue, "platform", "", "Platform to search: iphone (iOS), ipad (iPadOS), appletv (tvOS), visionos, or macos")
 
 	return cmd
 }

--- a/internal/sap/assets/assets.go
+++ b/internal/sap/assets/assets.go
@@ -93,9 +93,23 @@ func Load(ctx context.Context) (Bundle, error) {
 }
 
 func download(ctx context.Context) (Bundle, error) {
+	found, err := downloadFiles(ctx, requiredFiles, "download Apple SAP assets")
+	if err != nil {
+		return Bundle{}, err
+	}
+
+	bundle := bundleFrom(found)
+	if err := validate(bundle); err != nil {
+		return Bundle{}, err
+	}
+
+	return bundle, nil
+}
+
+func downloadFiles(ctx context.Context, specs []fileSpec, operation string) (map[string][]byte, error) {
 	parsed, err := url.Parse(updateURL)
 	if err != nil {
-		return Bundle{}, fmt.Errorf("parse Apple software update URL: %w", err)
+		return nil, fmt.Errorf("parse Apple software update URL: %w", err)
 	}
 
 	client := &http.Client{
@@ -105,17 +119,17 @@ func download(ctx context.Context) (Bundle, error) {
 
 	remote, err := ranger.NewReader(&ranger.HTTPRanger{Client: client, URL: parsed})
 	if err != nil {
-		return Bundle{}, fmt.Errorf("open Apple software update: %w", err)
+		return nil, fmt.Errorf("open Apple software update: %w", err)
 	}
 
 	length, err := remote.Length()
 	if err != nil {
-		return Bundle{}, fmt.Errorf("measure Apple software update: %w", err)
+		return nil, fmt.Errorf("measure Apple software update: %w", err)
 	}
 
 	container, err := xar.NewReader(remote, length)
 	if err != nil {
-		return Bundle{}, fmt.Errorf("read Apple software update: %w", err)
+		return nil, fmt.Errorf("read Apple software update: %w", err)
 	}
 
 	var payload *xar.File
@@ -129,32 +143,32 @@ func download(ctx context.Context) (Bundle, error) {
 	}
 
 	if payload == nil {
-		return Bundle{}, &fs.PathError{Op: "open", Path: payloadName, Err: fs.ErrNotExist}
+		return nil, &fs.PathError{Op: "open", Path: payloadName, Err: fs.ErrNotExist}
 	}
 
 	raw := payload.OpenRaw()
 	if _, err := raw.Seek(payloadBZOffset, io.SeekStart); err != nil {
-		return Bundle{}, fmt.Errorf("seek Apple update payload: %w", err)
+		return nil, fmt.Errorf("seek Apple update payload: %w", err)
 	}
 
 	compressed := io.MultiReader(bytes.NewReader([]byte{'B', 'Z', 'h', '9'}), raw)
 
 	archive := bzip2.NewReader(compressed)
 	if _, err := io.CopyN(io.Discard, archive, payloadCPIO); err != nil {
-		return Bundle{}, fmt.Errorf("seek Apple payload archive: %w", err)
+		return nil, fmt.Errorf("seek Apple payload archive: %w", err)
 	}
 
-	wanted := make(map[string]fileSpec, len(requiredFiles))
-	for _, spec := range requiredFiles {
+	wanted := make(map[string]fileSpec, len(specs))
+	for _, spec := range specs {
 		wanted[spec.path] = spec
 	}
 
-	found := make(map[string][]byte, len(requiredFiles))
+	found := make(map[string][]byte, len(specs))
 	reader := cpio.NewReader(archive)
 
 	for len(found) != len(wanted) {
 		if err := ctx.Err(); err != nil {
-			return Bundle{}, fmt.Errorf("download Apple SAP assets: %w", err)
+			return nil, fmt.Errorf("%s: %w", operation, err)
 		}
 
 		path, body, err := reader.Next()
@@ -163,7 +177,7 @@ func download(ctx context.Context) (Bundle, error) {
 		}
 
 		if err != nil {
-			return Bundle{}, fmt.Errorf("read Apple payload archive: %w", err)
+			return nil, fmt.Errorf("read Apple payload archive: %w", err)
 		}
 
 		spec, ok := wanted[path]
@@ -173,18 +187,13 @@ func download(ctx context.Context) (Bundle, error) {
 
 		data, err := io.ReadAll(io.LimitReader(body, int64(spec.size)+1))
 		if err != nil {
-			return Bundle{}, fmt.Errorf("read %s: %w", spec.name, err)
+			return nil, fmt.Errorf("read %s: %w", spec.name, err)
 		}
 
 		found[spec.name] = data
 	}
 
-	bundle := bundleFrom(found)
-	if err := validate(bundle); err != nil {
-		return Bundle{}, err
-	}
-
-	return bundle, nil
+	return found, nil
 }
 
 func cacheDirectory() (string, error) {

--- a/internal/sap/assets/assets_suite_test.go
+++ b/internal/sap/assets/assets_suite_test.go
@@ -1,0 +1,13 @@
+package assets
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAssetsGinkgo(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SAP Assets Suite")
+}

--- a/internal/sap/assets/storeagent.go
+++ b/internal/sap/assets/storeagent.go
@@ -1,0 +1,86 @@
+package assets
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const storeAgentCacheDirectory = "apple-storeagent-v1"
+
+var storeAgentSpec = fileSpec{
+	name:   "storeagent",
+	path:   "./System/Library/PrivateFrameworks/CommerceKit.framework/Versions/A/Resources/storeagent",
+	size:   2580176,
+	digest: mustDigest("70ce036f9dbcbc04db9511ebd08de0dd3cbc35ccc9d44b089c90170cb5453c59"),
+}
+
+// LoadStoreAgent loads the pinned StoreAgent image from its separate cache or Apple payload.
+func LoadStoreAgent(ctx context.Context) ([]byte, error) {
+	directory, err := storeAgentDirectory()
+	if err != nil {
+		return nil, err
+	}
+
+	path := filepath.Join(directory, storeAgentSpec.name)
+	if data, err := readStoreAgent(path); err == nil {
+		return data, nil
+	}
+
+	files, err := downloadFiles(ctx, []fileSpec{storeAgentSpec}, "download Apple StoreAgent asset")
+	if err != nil {
+		return nil, err
+	}
+
+	data := files[storeAgentSpec.name]
+	if err := VerifyStoreAgent(data); err != nil {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return nil, fmt.Errorf("create StoreAgent asset cache: %w", err)
+	}
+
+	if err := replaceFile(path, data); err != nil {
+		return nil, fmt.Errorf("cache Apple StoreAgent asset: %w", err)
+	}
+
+	return data, nil
+}
+
+func storeAgentDirectory() (string, error) {
+	root, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("find user cache directory: %w", err)
+	}
+
+	return filepath.Join(root, "ipatool", "sap", storeAgentCacheDirectory), nil
+}
+
+func readStoreAgent(path string) ([]byte, error) {
+	data, err := readCacheFile(path, storeAgentSpec.size)
+	if err != nil {
+		return nil, fmt.Errorf("read cached Apple StoreAgent asset: %w", err)
+	}
+
+	if err := VerifyStoreAgent(data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// VerifyStoreAgent verifies the image profile required by the StoreAgent runtime.
+func VerifyStoreAgent(data []byte) error {
+	if len(data) != storeAgentSpec.size {
+		return fmt.Errorf("apple StoreAgent asset has size %d, expected %d", len(data), storeAgentSpec.size)
+	}
+
+	if sha256.Sum256(data) != storeAgentSpec.digest {
+		return fmt.Errorf("apple StoreAgent asset failed integrity verification")
+	}
+
+	return nil
+}

--- a/internal/sap/assets/storeagent_test.go
+++ b/internal/sap/assets/storeagent_test.go
@@ -1,0 +1,32 @@
+package assets
+
+import (
+	"bytes"
+	"crypto/sha256"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("StoreAgent asset profile", func() {
+	It("pins the verified Apple payload asset", func() {
+		Expect(storeAgentSpec.name).To(Equal("storeagent"))
+		Expect(storeAgentSpec.path).To(Equal("./System/Library/PrivateFrameworks/CommerceKit.framework/Versions/A/Resources/storeagent"))
+		Expect(storeAgentSpec.size).To(Equal(2580176))
+		Expect(storeAgentSpec.digest).To(Equal(mustDigest("70ce036f9dbcbc04db9511ebd08de0dd3cbc35ccc9d44b089c90170cb5453c59")))
+	})
+
+	It("rejects an asset with the wrong size", func() {
+		Expect(VerifyStoreAgent(nil)).To(MatchError(ContainSubstring("has size 0, expected 2580176")))
+	})
+
+	It("rejects an asset with the wrong digest", func() {
+		data := bytes.Repeat([]byte{0xa5}, storeAgentSpec.size)
+		Expect(sha256.Sum256(data)).NotTo(Equal(storeAgentSpec.digest))
+		Expect(VerifyStoreAgent(data)).To(MatchError("apple StoreAgent asset failed integrity verification"))
+	})
+
+	It("uses a cache namespace separate from ordinary SAP assets", func() {
+		Expect(storeAgentCacheDirectory).NotTo(Equal("apple-assets-v2"))
+	})
+})

--- a/internal/sap/machine/machine.go
+++ b/internal/sap/machine/machine.go
@@ -56,76 +56,108 @@ type Machine struct {
 	closed        bool
 }
 
+type imageSpec struct {
+	name string
+	data []byte
+	base uint64
+}
+
+type runtimeOptions struct {
+	extraImages []imageSpec
+	shims       shimOptions
+}
+
 func Open(ctx context.Context, bundle assets.Bundle) (*Machine, error) {
+	machine, exports, err := openRuntime(ctx, bundle, runtimeOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	machine.entry = entryPoints{
+		initialize: exports["_cp2g1b9ro"],
+		exchange:   exports["_Mib5yocT"],
+		sign:       exports["_Fc3vhtJDvr"],
+		teardown:   exports["_IPaI1oem5iL"],
+		dispose:    exports["_jEHf8Xzsv8K"],
+	}
+
+	return machine, nil
+}
+
+func openRuntime(ctx context.Context, bundle assets.Bundle, options runtimeOptions) (*Machine, map[string]uint64, error) {
 	if ctx == nil {
-		return nil, errors.New("SAP runtime context is nil")
+		return nil, nil, errors.New("SAP runtime context is nil")
 	}
 
 	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("open SAP runtime: %w", err)
+		return nil, nil, fmt.Errorf("open SAP runtime: %w", err)
 	}
 
-	coreFP, err := machimage.Open("CoreFP", bundle.CoreFP)
-	if err != nil {
-		return nil, fmt.Errorf("open CoreFP image: %w", err)
-	}
+	imageSpecs := make([]imageSpec, 0, 3+len(options.extraImages))
+	imageSpecs = append(imageSpecs,
+		imageSpec{name: "CoreFP", data: bundle.CoreFP, base: coreFPBase},
+		imageSpec{name: "CommerceCore", data: bundle.CommerceCore, base: commerceBase},
+		imageSpec{name: "CommerceKit", data: bundle.CommerceKit, base: kitBase},
+	)
+	imageSpecs = append(imageSpecs, options.extraImages...)
 
-	commerceCore, err := machimage.Open("CommerceCore", bundle.CommerceCore)
-	if err != nil {
-		return nil, fmt.Errorf("open CommerceCore image: %w", err)
-	}
+	images := make(map[string]*machimage.Image, len(imageSpecs))
 
-	commerceKit, err := machimage.Open("CommerceKit", bundle.CommerceKit)
-	if err != nil {
-		return nil, fmt.Errorf("open CommerceKit image: %w", err)
+	for _, spec := range imageSpecs {
+		image, err := machimage.Open(spec.name, spec.data)
+		if err != nil {
+			return nil, nil, fmt.Errorf("open %s image: %w", spec.name, err)
+		}
+
+		images[spec.name] = image
 	}
 
 	exports := make(map[string]uint64)
 	coreExports := make(map[string]uint64, len(coreExportNames))
+	coreFP := images["CoreFP"]
 
 	for _, name := range coreExportNames {
 		address, err := coreFP.Export(name, coreFPBase)
 		if err != nil {
-			return nil, fmt.Errorf("resolve CoreFP export %s: %w", name, err)
+			return nil, nil, fmt.Errorf("resolve CoreFP export %s: %w", name, err)
 		}
 
 		exports[name] = address
 		coreExports[name] = address
 	}
 
+	commerceCore := images["CommerceCore"]
 	macAddress, err := commerceCore.Export("_get_mac_address", commerceBase)
+
 	if err != nil {
-		return nil, fmt.Errorf("resolve CommerceCore MAC address export: %w", err)
+		return nil, nil, fmt.Errorf("resolve CommerceCore MAC address export: %w", err)
 	}
 
 	exports["_get_mac_address"] = macAddress
 
-	entryNames := []string{
+	commerceKit := images["CommerceKit"]
+	for _, name := range []string{
 		"_cp2g1b9ro",
 		"_Mib5yocT",
 		"_Fc3vhtJDvr",
 		"_IPaI1oem5iL",
 		"_jEHf8Xzsv8K",
-	}
-	resolvedEntries := make(map[string]uint64, len(entryNames))
-
-	for _, name := range entryNames {
+	} {
 		address, err := commerceKit.Export(name, kitBase)
 		if err != nil {
-			return nil, fmt.Errorf("resolve CommerceKit export %s: %w", name, err)
+			return nil, nil, fmt.Errorf("resolve CommerceKit export %s: %w", name, err)
 		}
 
 		exports[name] = address
-		resolvedEntries[name] = address
 	}
 
 	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("open SAP runtime: %w", err)
+		return nil, nil, fmt.Errorf("open SAP runtime: %w", err)
 	}
 
 	engine, err := unicorn.New(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create Unicorn engine: %w", err)
+		return nil, nil, fmt.Errorf("create Unicorn engine: %w", err)
 	}
 
 	machine := &Machine{engine: engine}
@@ -147,17 +179,17 @@ func Open(ctx context.Context, bundle assets.Bundle) (*Machine, error) {
 		{stackBase, stackSize},
 	} {
 		if err := engine.MemMap(region.address, region.size); err != nil {
-			return nil, fmt.Errorf("map SAP guest memory at %#x: %w", region.address, err)
+			return nil, nil, fmt.Errorf("map SAP guest memory at %#x: %w", region.address, err)
 		}
 	}
 
 	if err := engine.MemWrite(returnAddress, []byte{0xF4}); err != nil {
-		return nil, fmt.Errorf("write SAP guest return instruction: %w", err)
+		return nil, nil, fmt.Errorf("write SAP guest return instruction: %w", err)
 	}
 
-	machine.services, err = newShims(engine, coreExports, bundle.CoreFPICXS)
+	machine.services, err = newShimsWithOptions(engine, coreExports, bundle.CoreFPICXS, options.shims)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	resolver := func(name string) (uint64, error) {
@@ -167,33 +199,21 @@ func Open(ctx context.Context, bundle assets.Bundle) (*Machine, error) {
 
 		return machine.services.resolve(name)
 	}
-	for _, item := range []struct {
-		image *machimage.Image
-		base  uint64
-	}{
-		{coreFP, coreFPBase},
-		{commerceCore, commerceBase},
-		{commerceKit, kitBase},
-	} {
-		if err := item.image.Relocate(item.base, resolver); err != nil {
-			return nil, fmt.Errorf("relocate SAP guest image: %w", err)
+
+	for _, spec := range imageSpecs {
+		image := images[spec.name]
+		if err := image.Relocate(spec.base, resolver); err != nil {
+			return nil, nil, fmt.Errorf("relocate SAP guest image: %w", err)
 		}
 
-		if err := item.image.Load(engine); err != nil {
-			return nil, fmt.Errorf("load SAP guest image: %w", err)
+		if err := image.Load(engine); err != nil {
+			return nil, nil, fmt.Errorf("load SAP guest image: %w", err)
 		}
 	}
 
-	machine.entry = entryPoints{
-		initialize: resolvedEntries["_cp2g1b9ro"],
-		exchange:   resolvedEntries["_Mib5yocT"],
-		sign:       resolvedEntries["_Fc3vhtJDvr"],
-		teardown:   resolvedEntries["_IPaI1oem5iL"],
-		dispose:    resolvedEntries["_jEHf8Xzsv8K"],
-	}
 	ready = true
 
-	return machine, nil
+	return machine, exports, nil
 }
 
 func (m *Machine) Initialize(hardwareID []byte) (uint64, error) {

--- a/internal/sap/machine/machine_suite_test.go
+++ b/internal/sap/machine/machine_suite_test.go
@@ -1,0 +1,13 @@
+package machine
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMachineGinkgo(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SAP Machine Suite")
+}

--- a/internal/sap/machine/shims.go
+++ b/internal/sap/machine/shims.go
@@ -33,6 +33,10 @@ type freeBlock struct {
 	size    uint64
 }
 
+type shimOptions struct {
+	zeroReturnAliases []string
+}
+
 type shims struct {
 	engine      *unicorn.Engine
 	hook        *unicorn.Hook
@@ -52,6 +56,10 @@ type shims struct {
 }
 
 func newShims(engine *unicorn.Engine, coreExports map[string]uint64, icxs []byte) (*shims, error) {
+	return newShimsWithOptions(engine, coreExports, icxs, shimOptions{})
+}
+
+func newShimsWithOptions(engine *unicorn.Engine, coreExports map[string]uint64, icxs []byte, options shimOptions) (*shims, error) {
 	if err := engine.MemMap(shimBase, shimSize); err != nil {
 		return nil, fmt.Errorf("map guest service area: %w", err)
 	}
@@ -72,6 +80,10 @@ func newShims(engine *unicorn.Engine, coreExports map[string]uint64, icxs []byte
 
 	if err := s.registerPlatformServices(); err != nil {
 		return nil, err
+	}
+
+	if err := s.addAliases(options.zeroReturnAliases, s.returnZero); err != nil {
+		return nil, fmt.Errorf("register profile guest services: %w", err)
 	}
 
 	var err error

--- a/internal/sap/machine/storeagent.go
+++ b/internal/sap/machine/storeagent.go
@@ -1,0 +1,333 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/majd/ipatool/v2/internal/sap/assets"
+)
+
+const (
+	storeAgentBase         = uint64(0x00001000c0000000)
+	storeAgentGlobalInit   = storeAgentBase + 0x0c5fc0
+	storeAgentSessionInit  = storeAgentBase + 0x0debd0
+	storeAgentDecryptEntry = storeAgentBase + 0x0ee700
+	storeAgentSessionClose = storeAgentBase + 0x1212d0
+	storeAgentChunkSize    = 0x8000
+	storeAgentSCInfoPath   = "/Users/Shared/SC Info"
+)
+
+var storeAgentZeroReturnAliases = []string{
+	"_pthread_rwlock_rdlock",
+	"_pthread_rwlock_rdlock$UNIX2003",
+	"_pthread_mutex_init",
+	"_pthread_mutex_destroy",
+	"_pthread_rwlock_destroy",
+}
+
+type StoreAgent struct {
+	mu           sync.Mutex
+	guest        *Machine
+	session      uint64
+	decryptEntry uint64
+	closeEntry   uint64
+	closed       bool
+}
+
+func OpenStoreAgent(ctx context.Context, bundle assets.Bundle, hardwareID, dpInfo []byte) (*StoreAgent, error) {
+	if ctx == nil {
+		return nil, errors.New("StoreAgent context is nil")
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("open StoreAgent runtime: %w", err)
+	}
+
+	image, err := assets.LoadStoreAgent(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load Apple StoreAgent asset: %w", err)
+	}
+
+	return openStoreAgent(ctx, bundle, image, hardwareID, dpInfo)
+}
+
+func openStoreAgent(ctx context.Context, bundle assets.Bundle, image, hardwareID, dpInfo []byte) (*StoreAgent, error) {
+	if ctx == nil {
+		return nil, errors.New("StoreAgent context is nil")
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("open StoreAgent runtime: %w", err)
+	}
+
+	if len(dpInfo) == 0 {
+		return nil, errors.New("StoreAgent dpInfo is empty")
+	}
+
+	if err := assets.VerifyStoreAgent(image); err != nil {
+		return nil, fmt.Errorf("verify Apple StoreAgent profile: %w", err)
+	}
+
+	hardware, err := hardwareBlock(hardwareID)
+	if err != nil {
+		return nil, err
+	}
+
+	guest, _, err := openRuntime(ctx, bundle, runtimeOptions{
+		extraImages: []imageSpec{{name: "storeagent", data: image, base: storeAgentBase}},
+		shims: shimOptions{
+			zeroReturnAliases: storeAgentZeroReturnAliases,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("start StoreAgent runtime: %w", err)
+	}
+
+	agent := &StoreAgent{
+		guest:        guest,
+		decryptEntry: storeAgentDecryptEntry,
+		closeEntry:   storeAgentSessionClose,
+	}
+	complete := false
+
+	defer func() {
+		if !complete {
+			_ = agent.Close()
+		}
+	}()
+
+	globalContext, err := agent.initializeGlobal(hardware)
+	if err != nil {
+		return nil, err
+	}
+
+	agent.session, err = agent.initializeSession(globalContext, dpInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	complete = true
+
+	return agent, nil
+}
+
+func (s *StoreAgent) initializeGlobal(hardware []byte) (uint32, error) {
+	s.guest.beginCall()
+	defer s.guest.clearScratch()
+
+	hardwareAddress, err := s.guest.scratch(hardware, uint64(len(hardware)))
+	if err != nil {
+		return 0, err
+	}
+
+	path := append([]byte(storeAgentSCInfoPath), 0)
+	pathAddress, err := s.guest.scratch(path, uint64(len(path)))
+
+	if err != nil {
+		return 0, err
+	}
+
+	contextField, err := s.guest.scratch(nil, 4)
+	if err != nil {
+		return 0, err
+	}
+
+	status, err := s.guest.invoke(storeAgentGlobalInit, 0, hardwareAddress, pathAddress, contextField)
+	if err != nil {
+		return 0, fmt.Errorf("initialize StoreAgent global context: %w", err)
+	}
+
+	if int32(status) != 0 {
+		return 0, fmt.Errorf("StoreAgent global initialization returned %d", int32(status))
+	}
+
+	value, err := s.guest.readUint32(contextField)
+	if err != nil {
+		return 0, err
+	}
+
+	if value == 0 {
+		return 0, errors.New("StoreAgent global initialization returned a null context")
+	}
+
+	return value, nil
+}
+
+func (s *StoreAgent) initializeSession(globalContext uint32, dpInfo []byte) (uint64, error) {
+	s.guest.beginCall()
+	defer s.guest.clearScratch()
+
+	dpInfoAddress, err := s.guest.scratch(dpInfo, uint64(len(dpInfo)))
+	if err != nil {
+		return 0, err
+	}
+
+	sessionField, err := s.guest.scratch(nil, 8)
+	if err != nil {
+		return 0, err
+	}
+
+	status, err := s.guest.invoke(
+		storeAgentSessionInit,
+		uint64(globalContext),
+		dpInfoAddress,
+		uint64(len(dpInfo)),
+		sessionField,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("initialize StoreAgent session: %w", err)
+	}
+
+	if int32(status) != 0 {
+		return 0, fmt.Errorf("StoreAgent session initialization returned %d", int32(status))
+	}
+
+	session, err := s.guest.readUint64(sessionField)
+	if err != nil {
+		return 0, err
+	}
+
+	if session == 0 {
+		return 0, errors.New("StoreAgent session initialization returned a null session")
+	}
+
+	return session, nil
+}
+
+func (s *StoreAgent) Decrypt(ctx context.Context, dst io.Writer, src io.Reader) (int64, error) {
+	if s == nil {
+		return 0, errors.New("StoreAgent is nil")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return 0, errors.New("StoreAgent is closed")
+	}
+
+	if ctx == nil {
+		return 0, errors.New("StoreAgent decryption context is nil")
+	}
+
+	if dst == nil {
+		return 0, errors.New("StoreAgent decryption destination is nil")
+	}
+
+	if src == nil {
+		return 0, errors.New("StoreAgent decryption source is nil")
+	}
+
+	return decryptStream(ctx, dst, src, s.decryptChunk)
+}
+
+func (s *StoreAgent) decryptChunk(data []byte) error {
+	s.guest.beginCall()
+	defer s.guest.clearScratch()
+
+	address, err := s.guest.scratch(data, uint64(len(data)))
+	if err != nil {
+		return err
+	}
+
+	status, err := s.guest.invoke(
+		s.decryptEntry,
+		s.session,
+		address,
+		uint64(len(data)),
+		address,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("decrypt StoreAgent chunk: %w", err)
+	}
+
+	if int32(status) != 0 {
+		return fmt.Errorf("StoreAgent decryption returned %d", int32(status))
+	}
+
+	if err := s.guest.engine.MemReadInto(data, address); err != nil {
+		return fmt.Errorf("read decrypted StoreAgent chunk: %w", err)
+	}
+
+	return nil
+}
+
+func decryptStream(ctx context.Context, dst io.Writer, src io.Reader, decrypt func([]byte) error) (int64, error) {
+	buffer := make([]byte, storeAgentChunkSize)
+
+	var written int64
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return written, fmt.Errorf("decrypt StoreAgent stream: %w", err)
+		}
+
+		count, readErr := io.ReadFull(src, buffer)
+		if count != 0 {
+			chunk := buffer[:count]
+			if err := decrypt(chunk); err != nil {
+				return written, err
+			}
+
+			n, err := dst.Write(chunk)
+			written += int64(n)
+
+			if err != nil {
+				return written, fmt.Errorf("write decrypted StoreAgent stream: %w", err)
+			}
+
+			if n != len(chunk) {
+				return written, fmt.Errorf("write decrypted StoreAgent stream: %w", io.ErrShortWrite)
+			}
+		}
+
+		switch {
+		case readErr == nil:
+			continue
+		case errors.Is(readErr, io.EOF), errors.Is(readErr, io.ErrUnexpectedEOF):
+			return written, nil
+		default:
+			return written, fmt.Errorf("read encrypted StoreAgent stream: %w", readErr)
+		}
+	}
+}
+
+func (s *StoreAgent) Close() error {
+	if s == nil {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return nil
+	}
+
+	s.closed = true
+
+	var errs []error
+
+	if s.guest != nil && s.session != 0 {
+		session := s.session
+		s.session = 0
+
+		status, err := s.guest.invoke(s.closeEntry, session)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("close StoreAgent session: %w", err))
+		} else if int32(status) != 0 {
+			errs = append(errs, fmt.Errorf("StoreAgent session close returned %d", int32(status)))
+		}
+	}
+
+	if s.guest != nil {
+		errs = append(errs, s.guest.Close())
+		s.guest = nil
+	}
+
+	return errors.Join(errs...)
+}

--- a/internal/sap/machine/storeagent_test.go
+++ b/internal/sap/machine/storeagent_test.go
@@ -1,0 +1,204 @@
+package machine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+
+	"github.com/majd/ipatool/v2/internal/sap/assets"
+	"github.com/majd/ipatool/v2/internal/sap/unicorn"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("StoreAgent", func() {
+	Describe("profile", func() {
+		It("pins the verified image base and entry offsets", func() {
+			Expect(storeAgentBase).To(Equal(uint64(0x00001000c0000000)))
+			Expect(storeAgentGlobalInit).To(Equal(storeAgentBase + 0x0c5fc0))
+			Expect(storeAgentSessionInit).To(Equal(storeAgentBase + 0x0debd0))
+			Expect(storeAgentDecryptEntry).To(Equal(storeAgentBase + 0x0ee700))
+			Expect(storeAgentSessionClose).To(Equal(storeAgentBase + 0x1212d0))
+		})
+
+		It("re-verifies the pinned image before opening the runtime", func() {
+			_, err := openStoreAgent(context.Background(), assets.Bundle{}, []byte("wrong image"), []byte{1}, []byte{1})
+			Expect(err).To(MatchError(ContainSubstring("verify Apple StoreAgent profile")))
+			Expect(err).To(MatchError(ContainSubstring("has size")))
+		})
+
+		It("adds only the StoreAgent synchronization aliases", func() {
+			machine := newGinkgoServiceMachine(shimOptions{zeroReturnAliases: storeAgentZeroReturnAliases})
+
+			for _, name := range storeAgentZeroReturnAliases {
+				address, ok := machine.services.symbols[name]
+				Expect(ok).To(BeTrue(), name)
+				Expect(machine.invoke(address)).To(Equal(uint64(0)))
+			}
+		})
+
+		It("does not add StoreAgent aliases to the default SAP profile", func() {
+			machine := newGinkgoServiceMachine(shimOptions{})
+			address, err := machine.services.resolve("_pthread_mutex_init")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = machine.invoke(address)
+			Expect(err).To(MatchError(ContainSubstring("unsupported import _pthread_mutex_init")))
+		})
+	})
+
+	Describe("streaming decryption", func() {
+		It("uses full 0x8000 chunks and a final partial chunk", func() {
+			input := bytes.Repeat([]byte{0x3c}, 2*storeAgentChunkSize+17)
+			var output bytes.Buffer
+			var sizes []int
+
+			written, err := decryptStream(context.Background(), &output, bytes.NewReader(input), func(chunk []byte) error {
+				sizes = append(sizes, len(chunk))
+				for index := range chunk {
+					chunk[index] ^= 0xff
+				}
+
+				return nil
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(written).To(Equal(int64(len(input))))
+			Expect(sizes).To(Equal([]int{storeAgentChunkSize, storeAgentChunkSize, 17}))
+			Expect(output.Bytes()).To(Equal(bytes.Repeat([]byte{0xc3}, len(input))))
+		})
+
+		It("does not invoke the decryptor for an empty stream", func() {
+			called := false
+			written, err := decryptStream(context.Background(), io.Discard, bytes.NewReader(nil), func([]byte) error {
+				called = true
+
+				return nil
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(written).To(BeZero())
+			Expect(called).To(BeFalse())
+		})
+
+		It("writes a partial read before returning its source error", func() {
+			sourceErr := errors.New("source failed")
+			source := io.MultiReader(bytes.NewReader([]byte("partial")), errorReader{err: sourceErr})
+			var output bytes.Buffer
+
+			written, err := decryptStream(context.Background(), &output, source, func(chunk []byte) error {
+				return nil
+			})
+
+			Expect(written).To(Equal(int64(len("partial"))))
+			Expect(output.String()).To(Equal("partial"))
+			Expect(err).To(MatchError(ContainSubstring(sourceErr.Error())))
+		})
+
+		It("stops before the next chunk when the context is canceled", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			input := bytes.Repeat([]byte{1}, 2*storeAgentChunkSize)
+			calls := 0
+
+			written, err := decryptStream(ctx, io.Discard, bytes.NewReader(input), func([]byte) error {
+				calls++
+				cancel()
+
+				return nil
+			})
+
+			Expect(calls).To(Equal(1))
+			Expect(written).To(Equal(int64(storeAgentChunkSize)))
+			Expect(err).To(MatchError(ContainSubstring(context.Canceled.Error())))
+		})
+
+		It("returns decryptor errors without writing the failed chunk", func() {
+			decryptErr := errors.New("decrypt failed")
+			var output bytes.Buffer
+
+			written, err := decryptStream(context.Background(), &output, bytes.NewReader([]byte("encrypted")), func([]byte) error {
+				return decryptErr
+			})
+
+			Expect(written).To(BeZero())
+			Expect(output.Len()).To(BeZero())
+			Expect(err).To(MatchError(decryptErr))
+		})
+
+		It("reports short writes", func() {
+			written, err := decryptStream(context.Background(), shortWriter{}, bytes.NewReader([]byte("encrypted")), func([]byte) error {
+				return nil
+			})
+
+			Expect(written).To(Equal(int64(1)))
+			Expect(err).To(MatchError(ContainSubstring(io.ErrShortWrite.Error())))
+		})
+	})
+
+	It("closes the session and machine idempotently", func() {
+		machine := newGinkgoServiceMachine(shimOptions{})
+		var closedSession uint64
+		closeEntry, err := machine.services.addFunction("test.storeagent.close", func() error {
+			value, argumentErr := machine.services.argument(0)
+			if argumentErr != nil {
+				return argumentErr
+			}
+
+			closedSession = value
+
+			return machine.services.setResult(0)
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		agent := &StoreAgent{guest: machine, session: 0x1234, closeEntry: closeEntry}
+		Expect(agent.Close()).To(Succeed())
+		Expect(closedSession).To(Equal(uint64(0x1234)))
+		Expect(agent.session).To(BeZero())
+		Expect(agent.guest).To(BeNil())
+		Expect(agent.Close()).To(Succeed())
+	})
+})
+
+type errorReader struct {
+	err error
+}
+
+func (r errorReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+type shortWriter struct{}
+
+func (shortWriter) Write([]byte) (int, error) {
+	return 1, nil
+}
+
+func newGinkgoServiceMachine(options shimOptions) *Machine {
+	engine, err := unicorn.New(context.Background())
+	Expect(err).NotTo(HaveOccurred())
+
+	for _, region := range []struct {
+		address uint64
+		size    uint64
+	}{
+		{returnAddress, pageSize},
+		{scratchBase, scratchSize},
+		{heapBase, heapSize},
+		{stackBase, stackSize},
+	} {
+		Expect(engine.MemMap(region.address, region.size)).To(Succeed())
+	}
+
+	Expect(engine.MemWrite(returnAddress, []byte{0xF4})).To(Succeed())
+
+	services, err := newShimsWithOptions(engine, map[string]uint64{}, nil, options)
+	Expect(err).NotTo(HaveOccurred())
+
+	machine := &Machine{engine: engine, services: services}
+
+	DeferCleanup(func() {
+		Expect(machine.Close()).To(Succeed())
+	})
+
+	return machine
+}

--- a/pkg/appstore/app_test.go
+++ b/pkg/appstore/app_test.go
@@ -94,5 +94,6 @@ var _ = Describe("App", func() {
 		}
 
 		Expect(fileName(app, "1.0")).To(Equal("app.bundle-id1_42_1.0.ipa"))
+		Expect(packageFileName(app, "1.0", PlatformMacOS)).To(Equal("app.bundle-id1_42_1.0.pkg"))
 	})
 })

--- a/pkg/appstore/appstore.go
+++ b/pkg/appstore/appstore.go
@@ -25,7 +25,7 @@ type AppStore interface {
 	// Purchase acquires a license for the desired app.
 	// Note: only free apps are supported.
 	Purchase(input PurchaseInput) error
-	// Download downloads the IPA package from the App Store to the desired location.
+	// Download downloads the app package from the App Store to the desired location.
 	Download(input DownloadInput) (DownloadOutput, error)
 	// ReplicateSinf replicates the sinf for the IPA package.
 	ReplicateSinf(input ReplicateSinfInput) error
@@ -48,6 +48,7 @@ type appstore struct {
 	bagClient           http.Client[bagResult]
 	ownedAppsClient     http.Client[[]byte]
 	httpClient          http.Client[interface{}]
+	macDecrypterFactory macPackageDecrypterFactory
 	actionSignerFactory ActionSignerFactory
 	authRetrySleep      func(time.Duration)
 	machine             machine.Machine
@@ -83,6 +84,7 @@ func NewAppStore(args Args) AppStore {
 		bagClient:           http.NewClient[bagResult](clientArgs),
 		ownedAppsClient:     http.NewClient[[]byte](clientArgs),
 		httpClient:          http.NewClient[interface{}](clientArgs),
+		macDecrypterFactory: defaultMacPackageDecrypterFactory,
 		actionSignerFactory: actionSignerFactory,
 		authRetrySleep:      time.Sleep,
 		machine:             args.Machine,

--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -2,10 +2,12 @@ package appstore
 
 import (
 	"archive/zip"
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -19,6 +21,7 @@ var (
 )
 
 type DownloadInput struct {
+	Context           context.Context
 	Account           Account
 	App               App
 	OutputPath        string
@@ -39,6 +42,14 @@ func (t *appstore) Download(input DownloadInput) (DownloadOutput, error) {
 	}
 
 	guid := strings.ReplaceAll(strings.ToUpper(macAddr), ":", "")
+
+	var machineGUID []byte
+	if input.Platform == PlatformMacOS {
+		guid, machineGUID, err = machineIdentity(macAddr)
+		if err != nil {
+			return DownloadOutput{}, fmt.Errorf("failed to resolve machine identity: %w", err)
+		}
+	}
 
 	externalVersionID := input.ExternalVersionID
 	if externalVersionID == "" && (input.Platform == PlatformAppleTV || input.Platform == PlatformVisionOS) {
@@ -87,30 +98,30 @@ func (t *appstore) Download(input DownloadInput) (DownloadOutput, error) {
 		version = fmt.Sprintf("%v", itemVersion)
 	}
 
-	destination, err := t.resolveDestinationPath(input.App, version, input.OutputPath)
+	destination, err := t.resolveDestinationPath(input.App, version, input.OutputPath, input.Platform)
 	if err != nil {
 		return DownloadOutput{}, fmt.Errorf("failed to resolve destination path: %w", err)
 	}
 
+	if input.Platform == PlatformMacOS {
+		return t.downloadMacPackage(input.Context, item, destination, machineGUID, input.Progress)
+	}
+
 	tmpPath := fmt.Sprintf("%s.tmp", destination)
 
-	err = t.downloadFile(item.URL, tmpPath, input.Progress)
-	if err != nil {
+	if err := t.downloadFile(input.Context, item.URL, tmpPath, input.Progress); err != nil {
 		return DownloadOutput{}, fmt.Errorf("failed to download file: %w", err)
 	}
 
-	err = t.applyPatches(item, input.Account, tmpPath, destination)
-	if err != nil {
+	if err := t.applyPatches(item, input.Account, tmpPath, destination); err != nil {
 		return DownloadOutput{}, fmt.Errorf("failed to apply patches: %w", err)
 	}
 
-	err = t.validatePackagePlatform(destination, input.Platform)
-	if err != nil {
+	if err := t.validatePackagePlatform(destination, input.Platform); err != nil {
 		return DownloadOutput{}, fmt.Errorf("failed to validate package platform: %w", err)
 	}
 
-	err = t.os.Remove(fmt.Sprintf("%s.tmp", destination))
-	if err != nil {
+	if err := t.os.Remove(tmpPath); err != nil {
 		return DownloadOutput{}, fmt.Errorf("failed to remove file: %w", err)
 	}
 
@@ -199,10 +210,18 @@ type downloadResult struct {
 	Items           []downloadItemResult `plist:"songList,omitempty"`
 }
 
-func (t *appstore) downloadFile(src, dst string, progress *progressbar.ProgressBar) error {
+func (t *appstore) downloadFile(ctx context.Context, src, dst string, progress *progressbar.ProgressBar) error {
 	req, err := t.httpClient.NewRequest("GET", src, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if req != nil {
+		req = req.WithContext(ctx)
 	}
 
 	file, err := t.os.OpenFile(dst, os.O_CREATE|os.O_RDWR, 0644)
@@ -285,6 +304,10 @@ func (*appstore) downloadRequest(acc Account, app App, guid string, externalVers
 }
 
 func fileName(app App, version string) string {
+	return packageFileName(app, version, "")
+}
+
+func packageFileName(app App, version string, platform Platform) string {
 	var parts []string
 
 	if app.BundleID != "" {
@@ -299,11 +322,16 @@ func fileName(app App, version string) string {
 		parts = append(parts, version)
 	}
 
-	return fmt.Sprintf("%s.ipa", strings.Join(parts, "_"))
+	extension := "ipa"
+	if platform == PlatformMacOS {
+		extension = "pkg"
+	}
+
+	return fmt.Sprintf("%s.%s", strings.Join(parts, "_"), extension)
 }
 
-func (t *appstore) resolveDestinationPath(app App, version string, path string) (string, error) {
-	file := fileName(app, version)
+func (t *appstore) resolveDestinationPath(app App, version string, path string, platform Platform) (string, error) {
+	file := packageFileName(app, version, platform)
 
 	if path == "" {
 		workdir, err := t.os.Getwd()
@@ -320,7 +348,7 @@ func (t *appstore) resolveDestinationPath(app App, version string, path string) 
 	}
 
 	if isDir {
-		return fmt.Sprintf("%s/%s", path, file), nil
+		return filepath.Join(path, file), nil
 	}
 
 	return path, nil

--- a/pkg/appstore/appstore_download_macos.go
+++ b/pkg/appstore/appstore_download_macos.go
@@ -1,0 +1,236 @@
+package appstore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/blacktop/go-macho/pkg/xar"
+	"github.com/schollz/progressbar/v3"
+)
+
+const (
+	macDPInfoSuffix         = ".dpInfo"
+	macHWInfoSuffix         = ".hwInfo"
+	macEncryptedStageSuffix = ".ipatool-encrypted"
+	macDecryptedStageSuffix = ".ipatool-decrypted"
+)
+
+type macPackageDecrypter interface {
+	Decrypt(ctx context.Context, dst io.Writer, src io.Reader) (int64, error)
+	Close() error
+}
+
+type macPackageDecrypterFactory func(ctx context.Context, hardwareID, dpInfo []byte) (macPackageDecrypter, error)
+
+func (t *appstore) downloadMacPackage(
+	ctx context.Context,
+	item downloadItemResult,
+	destination string,
+	hardwareID []byte,
+	progress *progressbar.ProgressBar,
+) (_ DownloadOutput, err error) {
+	dpInfo, err := macDPInfo(item.Sinfs)
+	if err != nil {
+		return DownloadOutput{}, err
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	encryptedPath := destination + macEncryptedStageSuffix
+	decryptedPath := destination + macDecryptedStageSuffix
+	stagePaths := []string{encryptedPath, decryptedPath}
+	published := false
+
+	if err := t.cleanupMacPaths(stagePaths...); err != nil {
+		return DownloadOutput{}, fmt.Errorf("failed to prepare macOS download staging: %w", err)
+	}
+
+	defer func() {
+		cleanupErr := t.cleanupMacPaths(stagePaths...)
+		if !published && cleanupErr != nil {
+			err = joinCleanupError(err, "failed to clean up macOS download staging", cleanupErr)
+		}
+	}()
+
+	if err := t.downloadFile(ctx, item.URL, encryptedPath, progress); err != nil {
+		return DownloadOutput{}, fmt.Errorf("failed to download file: %w", err)
+	}
+
+	factory := t.macDecrypterFactory
+	if factory == nil {
+		factory = defaultMacPackageDecrypterFactory
+	}
+
+	decrypter, err := factory(ctx, append([]byte(nil), hardwareID...), append([]byte(nil), dpInfo...))
+	if err != nil {
+		return DownloadOutput{}, fmt.Errorf("failed to initialize macOS package decrypter: %w", err)
+	}
+
+	if err := t.decryptMacPackage(ctx, decrypter, encryptedPath, decryptedPath); err != nil {
+		return DownloadOutput{}, err
+	}
+
+	if err := t.validateMacPackage(decryptedPath); err != nil {
+		return DownloadOutput{}, fmt.Errorf("failed to validate decrypted macOS package: %w", err)
+	}
+
+	if err := t.publishMacPackage(decryptedPath, destination); err != nil {
+		return DownloadOutput{}, err
+	}
+
+	published = true
+
+	// The validated package is already published at this point. Legacy sidecars
+	// are obsolete metadata, so their cleanup must not turn a successful package
+	// replacement into an error.
+	_ = t.removeLegacyMacSidecars(destination)
+
+	return DownloadOutput{DestinationPath: destination}, nil
+}
+
+func (t *appstore) decryptMacPackage(ctx context.Context, decrypter macPackageDecrypter, encryptedPath, decryptedPath string) (err error) {
+	decrypterClosed := false
+
+	var source *os.File
+
+	var destination *os.File
+
+	defer func() {
+		if destination != nil {
+			if closeErr := destination.Close(); closeErr != nil {
+				err = joinCleanupError(err, "failed to close decrypted macOS package staging", closeErr)
+			}
+		}
+
+		if source != nil {
+			if closeErr := source.Close(); closeErr != nil {
+				err = joinCleanupError(err, "failed to close encrypted macOS package", closeErr)
+			}
+		}
+
+		if !decrypterClosed {
+			if closeErr := decrypter.Close(); closeErr != nil {
+				err = joinCleanupError(err, "failed to close macOS package decrypter", closeErr)
+			}
+		}
+	}()
+
+	source, err = t.os.OpenFile(encryptedPath, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open encrypted macOS package: %w", err)
+	}
+
+	destination, err = t.os.OpenFile(decryptedPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to open decrypted macOS package staging: %w", err)
+	}
+
+	_, decryptErr := decrypter.Decrypt(ctx, destination, source)
+	destinationCloseErr := destination.Close()
+	destination = nil
+	sourceCloseErr := source.Close()
+	source = nil
+	decrypterCloseErr := decrypter.Close()
+	decrypterClosed = true
+
+	if decryptErr != nil {
+		err = fmt.Errorf("failed to decrypt macOS package: %w", decryptErr)
+	}
+
+	if destinationCloseErr != nil {
+		err = joinCleanupError(err, "failed to close decrypted macOS package staging", destinationCloseErr)
+	}
+
+	if sourceCloseErr != nil {
+		err = joinCleanupError(err, "failed to close encrypted macOS package", sourceCloseErr)
+	}
+
+	if decrypterCloseErr != nil {
+		err = joinCleanupError(err, "failed to close macOS package decrypter", decrypterCloseErr)
+	}
+
+	return err
+}
+
+func (t *appstore) validateMacPackage(path string) (err error) {
+	file, err := t.os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open decrypted macOS package: %w", err)
+	}
+
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			err = joinCleanupError(err, "failed to close decrypted macOS package", closeErr)
+		}
+	}()
+
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to inspect decrypted macOS package: %w", err)
+	}
+
+	if info.Size() == 0 {
+		return errors.New("decrypted package is empty")
+	}
+
+	archive, err := xar.NewReader(file, info.Size())
+	if err != nil {
+		return fmt.Errorf("failed to parse XAR archive: %w", err)
+	}
+
+	if len(archive.Files) == 0 {
+		return errors.New("XAR archive does not contain files")
+	}
+
+	for _, entry := range archive.Files {
+		if !entry.VerifyChecksum() {
+			return fmt.Errorf("XAR entry %q failed checksum validation", entry.Name)
+		}
+	}
+
+	return nil
+}
+
+func macDPInfo(sinfs []Sinf) ([]byte, error) {
+	var dpInfo []byte
+
+	for _, sinf := range sinfs {
+		if len(sinf.DPInfo) == 0 {
+			continue
+		}
+
+		if dpInfo != nil && !bytes.Equal(dpInfo, sinf.DPInfo) {
+			return nil, errors.New("download response contains conflicting dpInfo values")
+		}
+
+		dpInfo = sinf.DPInfo
+	}
+
+	if len(dpInfo) == 0 {
+		return nil, errors.New("download response does not contain dpInfo")
+	}
+
+	return append([]byte(nil), dpInfo...), nil
+}
+
+func (t *appstore) cleanupMacPaths(paths ...string) error {
+	var cleanupErr error
+
+	for _, path := range paths {
+		if err := t.os.Remove(path); err != nil && !t.os.IsNotExist(err) {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("failed to remove %s: %w", path, err))
+		}
+	}
+
+	return cleanupErr
+}
+
+func (t *appstore) removeLegacyMacSidecars(destination string) error {
+	return t.cleanupMacPaths(destination+macDPInfoSuffix, destination+macHWInfoSuffix)
+}

--- a/pkg/appstore/appstore_download_macos_adapter.go
+++ b/pkg/appstore/appstore_download_macos_adapter.go
@@ -1,0 +1,45 @@
+package appstore
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/majd/ipatool/v2/internal/sap/assets"
+	"github.com/majd/ipatool/v2/internal/sap/machine"
+)
+
+type storeAgentDecrypter struct {
+	agent *machine.StoreAgent
+}
+
+func defaultMacPackageDecrypterFactory(ctx context.Context, hardwareID, dpInfo []byte) (macPackageDecrypter, error) {
+	bundle, err := assets.Load(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load SAP assets: %w", err)
+	}
+
+	agent, err := machine.OpenStoreAgent(ctx, bundle, hardwareID, dpInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open StoreAgent: %w", err)
+	}
+
+	return &storeAgentDecrypter{agent: agent}, nil
+}
+
+func (d *storeAgentDecrypter) Decrypt(ctx context.Context, dst io.Writer, src io.Reader) (int64, error) {
+	written, err := d.agent.Decrypt(ctx, dst, src)
+	if err != nil {
+		return written, fmt.Errorf("failed to decrypt with StoreAgent: %w", err)
+	}
+
+	return written, nil
+}
+
+func (d *storeAgentDecrypter) Close() error {
+	if err := d.agent.Close(); err != nil {
+		return fmt.Errorf("failed to close StoreAgent: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/appstore/appstore_download_macos_publish.go
+++ b/pkg/appstore/appstore_download_macos_publish.go
@@ -1,0 +1,91 @@
+package appstore
+
+import (
+	"errors"
+	"fmt"
+)
+
+const macBackupSuffix = ".ipatool-backup"
+
+func (t *appstore) publishMacPackage(stagedPath, destination string) error {
+	backupPath, err := t.backupMacFile(destination)
+	if err != nil {
+		return fmt.Errorf("failed to preserve existing package: %w", err)
+	}
+
+	if err := t.os.Rename(stagedPath, destination); err != nil {
+		publishErr := fmt.Errorf("failed to publish package: %w", err)
+
+		return joinMacRollbackError(publishErr, t.restoreMacPackage(destination, backupPath))
+	}
+
+	if backupPath != "" {
+		_ = t.os.Remove(backupPath)
+	}
+
+	return nil
+}
+
+func (t *appstore) backupMacFile(path string) (string, error) {
+	_, err := t.os.Stat(path)
+	if err != nil {
+		if t.os.IsNotExist(err) {
+			return "", nil
+		}
+
+		return "", fmt.Errorf("failed to inspect destination package: %w", err)
+	}
+
+	backupPath, err := t.macBackupPath(path)
+	if err != nil {
+		return "", err
+	}
+
+	if err := t.os.Rename(path, backupPath); err != nil {
+		return "", fmt.Errorf("failed to back up destination package: %w", err)
+	}
+
+	return backupPath, nil
+}
+
+func (t *appstore) macBackupPath(path string) (string, error) {
+	for index := 0; ; index++ {
+		backupPath := path + macBackupSuffix
+		if index > 0 {
+			backupPath = fmt.Sprintf("%s.%d", backupPath, index)
+		}
+
+		_, err := t.os.Stat(backupPath)
+		if err != nil {
+			if t.os.IsNotExist(err) {
+				return backupPath, nil
+			}
+
+			return "", fmt.Errorf("failed to inspect package backup path: %w", err)
+		}
+	}
+}
+
+func (t *appstore) restoreMacPackage(destination, backupPath string) error {
+	var rollbackErr error
+
+	if err := t.os.Remove(destination); err != nil && !t.os.IsNotExist(err) {
+		rollbackErr = errors.Join(rollbackErr, fmt.Errorf("failed to remove partially published package: %w", err))
+	}
+
+	if backupPath != "" {
+		if err := t.os.Rename(backupPath, destination); err != nil {
+			rollbackErr = errors.Join(rollbackErr, fmt.Errorf("failed to restore package: %w", err))
+		}
+	}
+
+	return rollbackErr
+}
+
+func joinMacRollbackError(err, rollbackErr error) error {
+	if rollbackErr == nil {
+		return err
+	}
+
+	return joinCleanupError(err, "failed to restore existing macOS download", rollbackErr)
+}

--- a/pkg/appstore/appstore_download_macos_test.go
+++ b/pkg/appstore/appstore_download_macos_test.go
@@ -1,0 +1,352 @@
+package appstore
+
+import (
+	"bytes"
+	"compress/zlib"
+	"context"
+	"crypto/sha1" // #nosec G505 -- XAR uses SHA-1 for archive checksums.
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	gohttp "net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+
+	apphttp "github.com/majd/ipatool/v2/pkg/http"
+	"github.com/majd/ipatool/v2/pkg/util/operatingsystem"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AppStore (macOS download)", func() {
+	var (
+		server      *httptest.Server
+		destination string
+		encrypted   []byte
+		decrypted   []byte
+		dpInfo      []byte
+		hardwareID  []byte
+		decrypter   *fakeMacPackageDecrypter
+		factory     macPackageDecrypterFactory
+	)
+
+	BeforeEach(func() {
+		encrypted = []byte("encrypted package")
+		decrypted = makeTestXAR([]byte("decrypted payload"), false)
+		dpInfo = []byte("dp info")
+		hardwareID = []byte("hardware")
+
+		server = httptest.NewServer(gohttp.HandlerFunc(func(writer gohttp.ResponseWriter, _ *gohttp.Request) {
+			_, _ = writer.Write(encrypted)
+		}))
+		DeferCleanup(server.Close)
+
+		destination = filepath.Join(GinkgoT().TempDir(), "app.pkg")
+		decrypter = &fakeMacPackageDecrypter{output: decrypted}
+		factory = func(ctx context.Context, gotHardwareID, gotDPInfo []byte) (macPackageDecrypter, error) {
+			Expect(ctx).ToNot(BeNil())
+			Expect(gotHardwareID).To(Equal(hardwareID))
+			Expect(gotDPInfo).To(Equal(dpInfo))
+
+			return decrypter, nil
+		}
+	})
+
+	download := func(operatingSystem operatingsystem.OperatingSystem) (DownloadOutput, error) {
+		store := &appstore{
+			httpClient:          apphttp.NewClient[interface{}](apphttp.Args{}),
+			macDecrypterFactory: factory,
+			os:                  operatingSystem,
+		}
+
+		return store.downloadMacPackage(context.Background(), downloadItemResult{
+			URL:   server.URL,
+			Sinfs: []Sinf{{DPInfo: dpInfo}},
+		}, destination, hardwareID, nil)
+	}
+
+	expectNoStaging := func() {
+		Expect(destination + macEncryptedStageSuffix).ToNot(BeAnExistingFile())
+		Expect(destination + macDecryptedStageSuffix).ToNot(BeAnExistingFile())
+		Expect(destination + macBackupSuffix).ToNot(BeAnExistingFile())
+	}
+
+	It("publishes only the decrypted validated package", func() {
+		out, err := download(operatingsystem.New())
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).To(Equal(DownloadOutput{DestinationPath: destination}))
+		Expect(os.ReadFile(destination)).To(Equal(decrypted))
+		Expect(decrypter.input).To(Equal(encrypted))
+		Expect(decrypter.closed).To(BeTrue())
+		Expect(destination + macDPInfoSuffix).ToNot(BeAnExistingFile())
+		Expect(destination + macHWInfoSuffix).ToNot(BeAnExistingFile())
+		expectNoStaging()
+	})
+
+	It("replaces an existing package and removes legacy sidecars after success", func() {
+		Expect(os.WriteFile(destination, []byte("old package"), 0644)).To(Succeed())
+		Expect(os.WriteFile(destination+macDPInfoSuffix, []byte("old dp"), 0644)).To(Succeed())
+		Expect(os.WriteFile(destination+macHWInfoSuffix, []byte("old hw"), 0644)).To(Succeed())
+
+		_, err := download(operatingsystem.New())
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(os.ReadFile(destination)).To(Equal(decrypted))
+		Expect(destination + macDPInfoSuffix).ToNot(BeAnExistingFile())
+		Expect(destination + macHWInfoSuffix).ToNot(BeAnExistingFile())
+		expectNoStaging()
+	})
+
+	It("succeeds when legacy sidecar cleanup fails after publication", func() {
+		Expect(os.WriteFile(destination+macDPInfoSuffix, []byte("old dp"), 0644)).To(Succeed())
+		operatingSystem := &macDownloadFailureOS{
+			OperatingSystem: operatingsystem.New(),
+			removeErrorPath: destination + macDPInfoSuffix,
+		}
+
+		out, err := download(operatingSystem)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).To(Equal(DownloadOutput{DestinationPath: destination}))
+		Expect(os.ReadFile(destination)).To(Equal(decrypted))
+		Expect(os.ReadFile(destination + macDPInfoSuffix)).To(Equal([]byte("old dp")))
+		expectNoStaging()
+	})
+
+	It("preserves the existing package when decryption fails", func() {
+		Expect(os.WriteFile(destination, []byte("old package"), 0644)).To(Succeed())
+		decrypter.err = errors.New("decrypt failed")
+
+		_, err := download(operatingsystem.New())
+
+		Expect(err).To(MatchError(ContainSubstring("decrypt failed")))
+		Expect(os.ReadFile(destination)).To(Equal([]byte("old package")))
+		expectNoStaging()
+	})
+
+	It("cancels the package request and cleans staging", func() {
+		started := make(chan struct{})
+		cancelServer := httptest.NewServer(gohttp.HandlerFunc(func(writer gohttp.ResponseWriter, request *gohttp.Request) {
+			close(started)
+			<-request.Context().Done()
+		}))
+		DeferCleanup(cancelServer.Close)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		store := &appstore{
+			httpClient:          apphttp.NewClient[interface{}](apphttp.Args{}),
+			macDecrypterFactory: factory,
+			os:                  operatingsystem.New(),
+		}
+		done := make(chan error, 1)
+		go func() {
+			_, err := store.downloadMacPackage(ctx, downloadItemResult{
+				URL:   cancelServer.URL,
+				Sinfs: []Sinf{{DPInfo: dpInfo}},
+			}, destination, hardwareID, nil)
+			done <- err
+		}()
+
+		<-started
+		cancel()
+
+		Eventually(done).Should(Receive(MatchError(ContainSubstring(context.Canceled.Error()))))
+		Expect(destination).ToNot(BeAnExistingFile())
+		expectNoStaging()
+	})
+
+	It("preserves the existing package when decrypted output is not XAR", func() {
+		Expect(os.WriteFile(destination, []byte("old package"), 0644)).To(Succeed())
+		decrypter.output = []byte("not xar")
+
+		_, err := download(operatingsystem.New())
+
+		Expect(err).To(MatchError(ContainSubstring("failed to parse XAR archive")))
+		Expect(os.ReadFile(destination)).To(Equal([]byte("old package")))
+		expectNoStaging()
+	})
+
+	It("rejects a XAR without files", func() {
+		Expect(os.WriteFile(destination, []byte("old package"), 0644)).To(Succeed())
+		decrypter.output = makeEmptyTestXAR()
+
+		_, err := download(operatingsystem.New())
+
+		Expect(err).To(MatchError(ContainSubstring("does not contain files")))
+		Expect(os.ReadFile(destination)).To(Equal([]byte("old package")))
+		expectNoStaging()
+	})
+
+	It("rejects a XAR entry with an invalid checksum", func() {
+		Expect(os.WriteFile(destination, []byte("old package"), 0644)).To(Succeed())
+		decrypter.output = makeTestXAR([]byte("decrypted payload"), true)
+
+		_, err := download(operatingsystem.New())
+
+		Expect(err).To(MatchError(ContainSubstring("failed checksum validation")))
+		Expect(os.ReadFile(destination)).To(Equal([]byte("old package")))
+		expectNoStaging()
+	})
+
+	It("restores the existing package when publication fails", func() {
+		Expect(os.WriteFile(destination, []byte("old package"), 0644)).To(Succeed())
+		operatingSystem := &macDownloadFailureOS{
+			OperatingSystem: operatingsystem.New(),
+			renameErrorOld:  destination + macDecryptedStageSuffix,
+		}
+
+		_, err := download(operatingSystem)
+
+		Expect(err).To(MatchError(ContainSubstring("failed to publish package")))
+		Expect(os.ReadFile(destination)).To(Equal([]byte("old package")))
+		expectNoStaging()
+	})
+
+	It("does not replace an unrelated existing backup", func() {
+		Expect(os.WriteFile(destination, []byte("old package"), 0644)).To(Succeed())
+		backupPath := destination + macBackupSuffix
+		Expect(os.WriteFile(backupPath, []byte("unrelated backup"), 0644)).To(Succeed())
+
+		_, err := download(operatingsystem.New())
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(os.ReadFile(destination)).To(Equal(decrypted))
+		Expect(os.ReadFile(backupPath)).To(Equal([]byte("unrelated backup")))
+		Expect(destination + macBackupSuffix + ".1").ToNot(BeAnExistingFile())
+	})
+
+	It("rejects a download response without dpInfo before downloading", func() {
+		factoryCalled := false
+		factory = func(context.Context, []byte, []byte) (macPackageDecrypter, error) {
+			factoryCalled = true
+
+			return decrypter, nil
+		}
+		store := &appstore{
+			httpClient:          apphttp.NewClient[interface{}](apphttp.Args{}),
+			macDecrypterFactory: factory,
+			os:                  operatingsystem.New(),
+		}
+
+		_, err := store.downloadMacPackage(context.Background(), downloadItemResult{URL: server.URL}, destination, hardwareID, nil)
+
+		Expect(err).To(MatchError(ContainSubstring("dpInfo")))
+		Expect(factoryCalled).To(BeFalse())
+		Expect(destination).ToNot(BeAnExistingFile())
+	})
+
+	It("rejects conflicting dpInfo values", func() {
+		_, err := macDPInfo([]Sinf{{DPInfo: []byte("one")}, {DPInfo: []byte("two")}})
+		Expect(err).To(MatchError(ContainSubstring("conflicting")))
+	})
+})
+
+type fakeMacPackageDecrypter struct {
+	output []byte
+	input  []byte
+	err    error
+	closed bool
+}
+
+//nolint:wrapcheck
+func (f *fakeMacPackageDecrypter) Decrypt(_ context.Context, dst io.Writer, src io.Reader) (int64, error) {
+	input, err := io.ReadAll(src)
+	if err != nil {
+		return 0, err
+	}
+
+	f.input = input
+	if f.err != nil {
+		return 0, f.err
+	}
+
+	n, err := dst.Write(f.output)
+
+	return int64(n), err
+}
+
+func (f *fakeMacPackageDecrypter) Close() error {
+	f.closed = true
+
+	return nil
+}
+
+type macDownloadFailureOS struct {
+	operatingsystem.OperatingSystem
+	renameErrorOld  string
+	removeErrorPath string
+}
+
+//nolint:wrapcheck
+func (o *macDownloadFailureOS) Remove(path string) error {
+	if path == o.removeErrorPath {
+		return errors.New("remove failed")
+	}
+
+	return o.OperatingSystem.Remove(path)
+}
+
+//nolint:wrapcheck
+func (o *macDownloadFailureOS) Rename(oldPath, newPath string) error {
+	if oldPath == o.renameErrorOld {
+		return errors.New("rename failed")
+	}
+
+	return o.OperatingSystem.Rename(oldPath, newPath)
+}
+
+func makeEmptyTestXAR() []byte {
+	return makeTestXARArchive("")
+}
+
+func makeTestXAR(payload []byte, corruptFileChecksum bool) []byte {
+	payloadChecksum := sha1.Sum(payload) // #nosec G401 -- XAR uses SHA-1 for archive checksums.
+	checksum := payloadChecksum[:]
+
+	if corruptFileChecksum {
+		checksum = bytes.Repeat([]byte{0xff}, sha1.Size)
+	}
+
+	const tocChecksumSize = sha1.Size
+	fileXML := fmt.Sprintf(`<file id="1"><type>file</type><name>Payload</name><data><length>%d</length><offset>%d</offset><size>%d</size><encoding style="application/octet-stream"/><archived-checksum style="sha1">%s</archived-checksum><extracted-checksum style="sha1">%s</extracted-checksum></data></file>`,
+		len(payload),
+		tocChecksumSize,
+		len(payload),
+		hex.EncodeToString(checksum),
+		hex.EncodeToString(payloadChecksum[:]),
+	)
+
+	return makeTestXARArchive(fileXML, payload...)
+}
+
+func makeTestXARArchive(fileXML string, payload ...byte) []byte {
+	const tocChecksumSize = sha1.Size
+	toc := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<xar><toc><checksum style="sha1"><offset>0</offset><size>%d</size></checksum>%s</toc></xar>`, tocChecksumSize, fileXML)
+
+	var compressed bytes.Buffer
+	writer := zlib.NewWriter(&compressed)
+	_, err := writer.Write([]byte(toc))
+	Expect(err).ToNot(HaveOccurred())
+	Expect(writer.Close()).To(Succeed())
+
+	compressedTOC := compressed.Bytes()
+	tocChecksum := sha1.Sum(compressedTOC) // #nosec G401 -- XAR uses SHA-1 for archive checksums.
+
+	archive := make([]byte, 28+len(compressedTOC)+tocChecksumSize+len(payload))
+	binary.BigEndian.PutUint32(archive[0:4], 0x78617221)
+	binary.BigEndian.PutUint16(archive[4:6], 28)
+	binary.BigEndian.PutUint16(archive[6:8], 1)
+	binary.BigEndian.PutUint64(archive[8:16], uint64(len(compressedTOC)))
+	binary.BigEndian.PutUint64(archive[16:24], uint64(len(toc)))
+	binary.BigEndian.PutUint32(archive[24:28], 1)
+	copy(archive[28:], compressedTOC)
+	copy(archive[28+len(compressedTOC):], tocChecksum[:])
+	copy(archive[28+len(compressedTOC)+tocChecksumSize:], payload)
+
+	return archive
+}

--- a/pkg/appstore/appstore_download_test.go
+++ b/pkg/appstore/appstore_download_test.go
@@ -2,6 +2,8 @@ package appstore
 
 import (
 	"archive/zip"
+	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -9,6 +11,7 @@ import (
 	gohttp "net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -695,6 +698,111 @@ var _ = Describe("AppStore (Download)", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out.DestinationPath).ToNot(BeEmpty())
 			})
+		})
+	})
+
+	Describe("macOS packages", func() {
+		It("decrypts the downloaded package with in-memory machine identity and dpInfo", func() {
+			tempDir := GinkgoT().TempDir()
+			requestedPath := filepath.Join(tempDir, "custom-output.pkg")
+			packageData := []byte("encrypted package")
+			decryptedData := makeTestXAR([]byte("decrypted payload"), false)
+			dpInfo := bytes.Repeat([]byte{0x42}, 88)
+			decrypter := &fakeMacPackageDecrypter{output: decryptedData}
+
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:aa:bb:cc", nil)
+
+			mockDownloadClient.EXPECT().
+				Send(gomock.Any()).
+				Do(func(req http.Request) {
+					payload := req.Payload.(*http.XMLPayload)
+					Expect(payload.Content["guid"]).To(Equal("001122AABBCC"))
+				}).
+				Return(http.Result[downloadResult]{
+					StatusCode: 200,
+					Data: downloadResult{
+						Items: []downloadItemResult{{
+							URL:   "https://example.test/app.pkg",
+							Sinfs: []Sinf{{DPInfo: dpInfo}},
+							Metadata: map[string]interface{}{
+								"bundleShortVersionString": "1.2.3",
+							},
+						}},
+					},
+				}, nil)
+
+			mockHTTPClient.EXPECT().
+				NewRequest("GET", "https://example.test/app.pkg", nil).
+				Return(&gohttp.Request{Header: gohttp.Header{}}, nil)
+			mockHTTPClient.EXPECT().
+				Do(gomock.Any()).
+				Return(&gohttp.Response{
+					Body:          io.NopCloser(bytes.NewReader(packageData)),
+					ContentLength: int64(len(packageData)),
+				}, nil)
+
+			store := &appstore{
+				downloadClient: mockDownloadClient,
+				httpClient:     mockHTTPClient,
+				machine:        mockMachine,
+				os:             operatingsystem.New(),
+				macDecrypterFactory: func(ctx context.Context, hardwareID, gotDPInfo []byte) (macPackageDecrypter, error) {
+					Expect(ctx).ToNot(BeNil())
+					Expect(hardwareID).To(Equal([]byte{0x00, 0x11, 0x22, 0xaa, 0xbb, 0xcc}))
+					Expect(gotDPInfo).To(Equal(dpInfo))
+
+					return decrypter, nil
+				},
+			}
+			out, err := store.Download(DownloadInput{
+				Context:    context.Background(),
+				App:        App{ID: 42, BundleID: "com.example.mac"},
+				OutputPath: requestedPath,
+				Platform:   PlatformMacOS,
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(Equal(DownloadOutput{DestinationPath: requestedPath}))
+			Expect(decrypter.input).To(Equal(packageData))
+			Expect(os.ReadFile(requestedPath)).To(Equal(decryptedData))
+			Expect(requestedPath + macDPInfoSuffix).ToNot(BeAnExistingFile())
+			Expect(requestedPath + macHWInfoSuffix).ToNot(BeAnExistingFile())
+		})
+
+		It("uses a pkg name derived from the generated package name", func() {
+			store := &appstore{os: operatingsystem.New()}
+			tempDir := GinkgoT().TempDir()
+
+			packagePath, err := store.resolveDestinationPath(
+				App{ID: 42, BundleID: "com.example.mac"},
+				"1.2.3",
+				tempDir,
+				PlatformMacOS,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packagePath).To(Equal(filepath.Join(tempDir, "com.example.mac_42_1.2.3.pkg")))
+		})
+
+		It("preserves an explicit output path", func() {
+			store := &appstore{os: operatingsystem.New()}
+			tempDir := GinkgoT().TempDir()
+			requestedPath := filepath.Join(tempDir, "custom-output")
+
+			packagePath, err := store.resolveDestinationPath(App{}, "1.2.3", requestedPath, PlatformMacOS)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packagePath).To(Equal(requestedPath))
+		})
+
+		It("rejects a download response without dpInfo", func() {
+			_, err := macDPInfo(nil)
+			Expect(err).To(MatchError(ContainSubstring("dpInfo")))
+		})
+
+		It("rejects conflicting dpInfo values", func() {
+			_, err := macDPInfo([]Sinf{{DPInfo: []byte("one")}, {DPInfo: []byte("two")}})
+			Expect(err).To(MatchError(ContainSubstring("conflicting")))
 		})
 	})
 

--- a/pkg/appstore/appstore_lookup_test.go
+++ b/pkg/appstore/appstore_lookup_test.go
@@ -86,6 +86,29 @@ var _ = Describe("AppStore (Lookup)", func() {
 		})
 	})
 
+	When("platform is macOS", func() {
+		BeforeEach(func() {
+			mockClient.EXPECT().
+				Send(gomock.Any()).
+				Do(func(req http.Request) {
+					parsedURL, err := url.Parse(req.URL)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(parsedURL.Query().Get("entity")).To(Equal("macSoftware"))
+				}).
+				Return(http.Result[searchResult]{}, errors.New("request error"))
+		})
+
+		It("uses the macOS lookup entity", func() {
+			_, err := as.Lookup(LookupInput{
+				Account: Account{
+					StoreFront: "143441",
+				},
+				Platform: PlatformMacOS,
+			})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	When("platform is AppleTV", func() {
 		BeforeEach(func() {
 			mockClient.EXPECT().

--- a/pkg/appstore/appstore_purchase.go
+++ b/pkg/appstore/appstore_purchase.go
@@ -17,8 +17,9 @@ var (
 )
 
 type PurchaseInput struct {
-	Account Account
-	App     App
+	Account  Account
+	App      App
+	Platform Platform
 }
 
 func (t *appstore) Purchase(input PurchaseInput) error {
@@ -35,7 +36,7 @@ func (t *appstore) Purchase(input PurchaseInput) error {
 
 	err = t.purchaseWithParams(input.Account, input.App, guid, PricingParameterAppStore)
 	if err != nil {
-		if err == ErrTemporarilyUnavailable {
+		if input.Platform != PlatformMacOS && err == ErrTemporarilyUnavailable {
 			err = t.purchaseWithParams(input.Account, input.App, guid, PricingParameterAppleArcade)
 			if err != nil {
 				return fmt.Errorf("failed to purchase item with param '%s': %w", PricingParameterAppleArcade, err)

--- a/pkg/appstore/appstore_purchase_test.go
+++ b/pkg/appstore/appstore_purchase_test.go
@@ -368,6 +368,96 @@ var _ = Describe("AppStore (Purchase)", func() {
 		})
 	})
 
+	When("purchasing a macOS app", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			mockPurchaseClient.EXPECT().
+				Send(pricingParametersMatcher{PricingParameterAppStore}).
+				Return(http.Result[purchaseResult]{
+					StatusCode: 200,
+					Data: purchaseResult{
+						JingleDocType: "purchaseSuccess",
+						Status:        0,
+					},
+				}, nil)
+		})
+
+		It("uses the standard acquisition pricing parameter", func() {
+			err := as.Purchase(PurchaseInput{
+				Account:  Account{StoreFront: "143441"},
+				App:      App{ID: 42},
+				Platform: PlatformMacOS,
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	When("macOS purchase is temporarily unavailable", func() {
+		BeforeEach(func() {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			mockPurchaseClient.EXPECT().
+				Send(pricingParametersMatcher{PricingParameterAppStore}).
+				Return(http.Result[purchaseResult]{
+					StatusCode: 200,
+					Data: purchaseResult{
+						FailureType: FailureTypeTemporarilyUnavailable,
+					},
+				}, nil)
+		})
+
+		It("does not fall back to the GAME pricing parameter", func() {
+			err := as.Purchase(PurchaseInput{
+				Account:  Account{StoreFront: "143441"},
+				App:      App{ID: 42},
+				Platform: PlatformMacOS,
+			})
+			Expect(err).To(MatchError(ContainSubstring(PricingParameterAppStore)))
+		})
+	})
+
+	DescribeTable("falls back to the GAME pricing parameter for non-macOS platforms",
+		func(platform Platform) {
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:33:44:55", nil)
+
+			mockPurchaseClient.EXPECT().
+				Send(pricingParametersMatcher{PricingParameterAppStore}).
+				Return(http.Result[purchaseResult]{
+					StatusCode: 200,
+					Data: purchaseResult{
+						FailureType: FailureTypeTemporarilyUnavailable,
+					},
+				}, nil)
+			mockPurchaseClient.EXPECT().
+				Send(pricingParametersMatcher{PricingParameterAppleArcade}).
+				Return(http.Result[purchaseResult]{
+					StatusCode: 200,
+					Data: purchaseResult{
+						JingleDocType: "purchaseSuccess",
+						Status:        0,
+					},
+				}, nil)
+
+			err := as.Purchase(PurchaseInput{
+				Account:  Account{StoreFront: "143441"},
+				App:      App{ID: 42},
+				Platform: platform,
+			})
+			Expect(err).ToNot(HaveOccurred())
+		},
+		Entry("iPhone", PlatformIPhone),
+		Entry("iPad", PlatformIPad),
+		Entry("Apple TV", PlatformAppleTV),
+		Entry("visionOS", PlatformVisionOS),
+	)
+
 	When("successfully purchases the app", func() {
 		BeforeEach(func() {
 			mockMachine.EXPECT().

--- a/pkg/appstore/appstore_replicate_sinf.go
+++ b/pkg/appstore/appstore_replicate_sinf.go
@@ -15,8 +15,9 @@ import (
 )
 
 type Sinf struct {
-	ID   int64  `plist:"id,omitempty"`
-	Data []byte `plist:"sinf,omitempty"`
+	ID     int64  `plist:"id,omitempty"`
+	Data   []byte `plist:"sinf,omitempty"`
+	DPInfo []byte `plist:"dpInfo,omitempty"`
 }
 
 type ReplicateSinfInput struct {

--- a/pkg/appstore/appstore_search_test.go
+++ b/pkg/appstore/appstore_search_test.go
@@ -80,6 +80,29 @@ var _ = Describe("AppStore (Search)", func() {
 		})
 	})
 
+	When("platform is macOS", func() {
+		BeforeEach(func() {
+			mockClient.EXPECT().
+				Send(gomock.Any()).
+				Do(func(req http.Request) {
+					parsedURL, err := url.Parse(req.URL)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(parsedURL.Query().Get("entity")).To(Equal("macSoftware"))
+				}).
+				Return(http.Result[searchResult]{}, errors.New("request error"))
+		})
+
+		It("uses the macOS search entity", func() {
+			_, err := as.Search(SearchInput{
+				Account: Account{
+					StoreFront: "143441",
+				},
+				Platform: PlatformMacOS,
+			})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	When("platform is AppleTV", func() {
 		BeforeEach(func() {
 			mockClient.EXPECT().

--- a/pkg/appstore/platform.go
+++ b/pkg/appstore/platform.go
@@ -12,6 +12,7 @@ const (
 	PlatformIPad     Platform = "ipad"
 	PlatformAppleTV  Platform = "appletv"
 	PlatformVisionOS Platform = "visionos"
+	PlatformMacOS    Platform = "macos"
 )
 
 func ParsePlatform(value string) (Platform, error) {
@@ -26,6 +27,8 @@ func ParsePlatform(value string) (Platform, error) {
 		return PlatformAppleTV, nil
 	case "vision", "visionos", "visionpro", "xros", "realitydevice":
 		return PlatformVisionOS, nil
+	case "mac", "macos", "osx":
+		return PlatformMacOS, nil
 	default:
 		return "", fmt.Errorf("invalid platform %q", value)
 	}
@@ -43,6 +46,8 @@ func (p Platform) lookupEntity() (string, error) {
 		return "tvSoftware", nil
 	case PlatformVisionOS:
 		return "xrosSoftware", nil
+	case PlatformMacOS:
+		return "macSoftware", nil
 	default:
 		return "", fmt.Errorf("invalid platform %q", p)
 	}
@@ -60,6 +65,8 @@ func (p Platform) searchEntity() (string, error) {
 		return "software,tvSoftware", nil
 	case PlatformVisionOS:
 		return "xrosSoftware", nil
+	case PlatformMacOS:
+		return "macSoftware", nil
 	default:
 		return "", fmt.Errorf("invalid platform %q", p)
 	}

--- a/pkg/appstore/platform_test.go
+++ b/pkg/appstore/platform_test.go
@@ -23,6 +23,9 @@ var _ = Describe("Platform", func() {
 		Entry("Vision Pro", "visionpro", PlatformVisionOS),
 		Entry("xrOS", "xrOS", PlatformVisionOS),
 		Entry("realityDevice", "realityDevice", PlatformVisionOS),
+		Entry("Mac", "mac", PlatformMacOS),
+		Entry("macOS", "macOS", PlatformMacOS),
+		Entry("OS X", "osx", PlatformMacOS),
 	)
 
 	DescribeTable("maps platforms to lookup entities",
@@ -36,6 +39,7 @@ var _ = Describe("Platform", func() {
 		Entry("iPad", PlatformIPad, "iPadSoftware"),
 		Entry("Apple TV", PlatformAppleTV, "tvSoftware"),
 		Entry("visionOS", PlatformVisionOS, "xrosSoftware"),
+		Entry("macOS", PlatformMacOS, "macSoftware"),
 	)
 
 	DescribeTable("maps platforms to search entities",
@@ -49,6 +53,7 @@ var _ = Describe("Platform", func() {
 		Entry("iPad", PlatformIPad, "iPadSoftware"),
 		Entry("Apple TV", PlatformAppleTV, "software,tvSoftware"),
 		Entry("visionOS", PlatformVisionOS, "xrosSoftware"),
+		Entry("macOS", PlatformMacOS, "macSoftware"),
 	)
 
 	DescribeTable("maps platforms to metadata platforms",


### PR DESCRIPTION
## Summary

- add macOS support to app search, purchase, and download commands
- download macOS app packages as `.pkg` files without SINF replication
- pass the selected platform through lookup and purchase operations
- update CLI help and README documentation
- add coverage for macOS download and purchase behavior

## Testing

- `go generate ./...`
- `go test ./...`
- `go build ./...`