### PR TITLE
Fix iOS app downloads on macOS

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -182,7 +182,7 @@ type sinfReplicator interface {
 
 //nolint:wrapcheck
 func replicateDownloadSinf(store sinfReplicator, platform appstore.Platform, out appstore.DownloadOutput) error {
-	if platform == appstore.PlatformMacOS {
+	if platform == appstore.PlatformMacOS && len(out.Sinfs) == 0 {
 		return nil
 	}
 

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -26,6 +26,23 @@ var _ = Describe("Download command", func() {
 		Expect(replicator.called).To(BeFalse())
 	})
 
+	It("replicates sinf for mobile packages downloaded for macOS", func() {
+		replicator := &fakeSinfReplicator{}
+		out := appstore.DownloadOutput{
+			DestinationPath: "app.ipa",
+			Sinfs:           []appstore.Sinf{{Data: []byte("sinf")}},
+		}
+
+		err := replicateDownloadSinf(replicator, appstore.PlatformMacOS, out)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(replicator.called).To(BeTrue())
+		Expect(replicator.input).To(Equal(appstore.ReplicateSinfInput{
+			PackagePath: out.DestinationPath,
+			Sinfs:       out.Sinfs,
+		}))
+	})
+
 	It("replicates sinf for non-macOS packages", func() {
 		replicator := &fakeSinfReplicator{}
 		out := appstore.DownloadOutput{

--- a/pkg/appstore/appstore_download.go
+++ b/pkg/appstore/appstore_download.go
@@ -98,12 +98,17 @@ func (t *appstore) Download(input DownloadInput) (DownloadOutput, error) {
 		version = fmt.Sprintf("%v", itemVersion)
 	}
 
-	destination, err := t.resolveDestinationPath(input.App, version, input.OutputPath, input.Platform)
+	packagePlatform, err := downloadPackagePlatform(input.Platform, item)
+	if err != nil {
+		return DownloadOutput{}, err
+	}
+
+	destination, err := t.resolveDestinationPath(input.App, version, input.OutputPath, packagePlatform)
 	if err != nil {
 		return DownloadOutput{}, fmt.Errorf("failed to resolve destination path: %w", err)
 	}
 
-	if input.Platform == PlatformMacOS {
+	if packagePlatform == PlatformMacOS {
 		return t.downloadMacPackage(input.Context, item, destination, machineGUID, input.Progress)
 	}
 

--- a/pkg/appstore/appstore_download_package.go
+++ b/pkg/appstore/appstore_download_package.go
@@ -1,0 +1,74 @@
+package appstore
+
+import (
+	"errors"
+	"strings"
+)
+
+func downloadPackagePlatform(platform Platform, item downloadItemResult) (Platform, error) {
+	if platform != PlatformMacOS {
+		return platform, nil
+	}
+
+	softwarePlatform := downloadMetadataString(item.Metadata, "software-platform")
+	productType := downloadMetadataString(item.Metadata, "product-type")
+	mobileMetadata := strings.EqualFold(softwarePlatform, "ios") || strings.EqualFold(productType, "ios-app")
+	macMetadata := strings.EqualFold(softwarePlatform, "macos") || strings.EqualFold(productType, "mac-os-app")
+	mobileSinf := hasMobileSinf(item.Sinfs)
+	mobileSinfEvidence := hasMobileSinfEvidence(item.Sinfs)
+	macDPInfo := hasMacDPInfo(item.Sinfs)
+
+	if (mobileMetadata && macMetadata) || (mobileMetadata && macDPInfo) || (macMetadata && mobileSinfEvidence) || (mobileSinfEvidence && macDPInfo) {
+		return "", errors.New("download response contains conflicting package metadata")
+	}
+
+	if mobileMetadata || mobileSinfEvidence {
+		if !mobileSinf {
+			return "", errors.New("download response does not contain mobile sinf data")
+		}
+
+		return PlatformIPhone, nil
+	}
+
+	return PlatformMacOS, nil
+}
+
+func downloadMetadataString(metadata map[string]interface{}, key string) string {
+	value, _ := metadata[key].(string)
+
+	return value
+}
+
+func hasMobileSinf(sinfs []Sinf) bool {
+	if len(sinfs) == 0 {
+		return false
+	}
+
+	for _, sinf := range sinfs {
+		if len(sinf.Data) == 0 || len(sinf.DPInfo) > 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+func hasMobileSinfEvidence(sinfs []Sinf) bool {
+	for _, sinf := range sinfs {
+		if len(sinf.Data) > 0 && len(sinf.DPInfo) == 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasMacDPInfo(sinfs []Sinf) bool {
+	for _, sinf := range sinfs {
+		if len(sinf.DPInfo) > 0 {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/appstore/appstore_download_package_test.go
+++ b/pkg/appstore/appstore_download_package_test.go
@@ -1,0 +1,102 @@
+package appstore
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Download package platform", func() {
+	It("uses the requested platform for native macOS packages", func() {
+		item := downloadItemResult{
+			Metadata: map[string]interface{}{
+				"software-platform": "macos",
+				"product-type":      "mac-os-app",
+			},
+			Sinfs: []Sinf{{DPInfo: []byte("dp info")}},
+		}
+
+		platform, err := downloadPackagePlatform(PlatformMacOS, item)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(platform).To(Equal(PlatformMacOS))
+	})
+
+	It("accepts native authorization data that also contains sinf data", func() {
+		item := downloadItemResult{
+			Metadata: map[string]interface{}{
+				"software-platform": "macos",
+				"product-type":      "mac-os-app",
+			},
+			Sinfs: []Sinf{{Data: []byte("sinf"), DPInfo: []byte("dp info")}},
+		}
+
+		platform, err := downloadPackagePlatform(PlatformMacOS, item)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(platform).To(Equal(PlatformMacOS))
+	})
+
+	It("recognizes iOS apps made available on macOS", func() {
+		item := downloadItemResult{
+			Metadata: map[string]interface{}{
+				"software-platform": "ios",
+				"product-type":      "ios-app",
+			},
+			Sinfs: []Sinf{{Data: []byte("sinf")}},
+		}
+
+		platform, err := downloadPackagePlatform(PlatformMacOS, item)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(platform).To(Equal(PlatformIPhone))
+	})
+
+	It("uses mobile sinf data when platform metadata is absent", func() {
+		platform, err := downloadPackagePlatform(PlatformMacOS, downloadItemResult{
+			Sinfs: []Sinf{{Data: []byte("sinf")}},
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(platform).To(Equal(PlatformIPhone))
+	})
+
+	It("rejects mobile metadata without usable sinf data", func() {
+		_, err := downloadPackagePlatform(PlatformMacOS, downloadItemResult{
+			Metadata: map[string]interface{}{"software-platform": "ios"},
+		})
+
+		Expect(err).To(MatchError(ContainSubstring("mobile sinf")))
+	})
+
+	It("rejects conflicting platform metadata", func() {
+		_, err := downloadPackagePlatform(PlatformMacOS, downloadItemResult{
+			Metadata: map[string]interface{}{
+				"software-platform": "macos",
+				"product-type":      "ios-app",
+			},
+			Sinfs: []Sinf{{Data: []byte("sinf")}},
+		})
+
+		Expect(err).To(MatchError(ContainSubstring("conflicting")))
+	})
+
+	It("rejects conflicting authorization data", func() {
+		_, err := downloadPackagePlatform(PlatformMacOS, downloadItemResult{
+			Sinfs: []Sinf{
+				{Data: []byte("sinf")},
+				{DPInfo: []byte("dp info")},
+			},
+		})
+
+		Expect(err).To(MatchError(ContainSubstring("conflicting")))
+	})
+
+	It("does not override non-macOS requests", func() {
+		platform, err := downloadPackagePlatform(PlatformIPad, downloadItemResult{
+			Metadata: map[string]interface{}{
+				"software-platform": "macos",
+				"product-type":      "mac-os-app",
+			},
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(platform).To(Equal(PlatformIPad))
+	})
+})

--- a/pkg/appstore/appstore_download_test.go
+++ b/pkg/appstore/appstore_download_test.go
@@ -728,6 +728,8 @@ var _ = Describe("AppStore (Download)", func() {
 							Sinfs: []Sinf{{DPInfo: dpInfo}},
 							Metadata: map[string]interface{}{
 								"bundleShortVersionString": "1.2.3",
+								"software-platform":        "macos",
+								"product-type":             "mac-os-app",
 							},
 						}},
 					},
@@ -769,6 +771,81 @@ var _ = Describe("AppStore (Download)", func() {
 			Expect(os.ReadFile(requestedPath)).To(Equal(decryptedData))
 			Expect(requestedPath + macDPInfoSuffix).ToNot(BeAnExistingFile())
 			Expect(requestedPath + macHWInfoSuffix).ToNot(BeAnExistingFile())
+		})
+
+		It("downloads an iOS app available on macOS through the mobile package pipeline", func() {
+			tempDir := GinkgoT().TempDir()
+			requestedPath := filepath.Join(tempDir, "developer.apple.wwdc-Release_640199958_11.0.2.ipa")
+			packageBuffer := new(bytes.Buffer)
+			packageWriter := zip.NewWriter(packageBuffer)
+			infoWriter, err := packageWriter.Create("Payload/Developer.app/Info.plist")
+			Expect(err).ToNot(HaveOccurred())
+			info, err := plist.Marshal(map[string]interface{}{
+				"CFBundleExecutable":         "Developer",
+				"CFBundleSupportedPlatforms": []string{"iPhoneOS"},
+			}, plist.BinaryFormat)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = infoWriter.Write(info)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(packageWriter.Close()).To(Succeed())
+
+			mockMachine.EXPECT().
+				MacAddress().
+				Return("00:11:22:aa:bb:cc", nil)
+			mockDownloadClient.EXPECT().
+				Send(gomock.Any()).
+				Return(http.Result[downloadResult]{
+					StatusCode: 200,
+					Data: downloadResult{
+						Items: []downloadItemResult{{
+							URL: "https://example.test/developer.ipa",
+							Sinfs: []Sinf{{
+								ID:   0,
+								Data: []byte("mobile sinf"),
+							}},
+							Metadata: map[string]interface{}{
+								"bundleShortVersionString": "11.0.2",
+								"software-platform":        "ios",
+								"product-type":             "ios-app",
+							},
+						}},
+					},
+				}, nil)
+			mockHTTPClient.EXPECT().
+				NewRequest("GET", "https://example.test/developer.ipa", nil).
+				Return(&gohttp.Request{Header: gohttp.Header{}}, nil)
+			mockHTTPClient.EXPECT().
+				Do(gomock.Any()).
+				Return(&gohttp.Response{
+					Body:          io.NopCloser(bytes.NewReader(packageBuffer.Bytes())),
+					ContentLength: int64(packageBuffer.Len()),
+				}, nil)
+
+			store := &appstore{
+				downloadClient: mockDownloadClient,
+				httpClient:     mockHTTPClient,
+				machine:        mockMachine,
+				os:             operatingsystem.New(),
+				macDecrypterFactory: func(context.Context, []byte, []byte) (macPackageDecrypter, error) {
+					Fail("mobile packages must not initialize the macOS package decrypter")
+					return nil, nil
+				},
+			}
+
+			out, err := store.Download(DownloadInput{
+				Context:    context.Background(),
+				Account:    Account{Email: "test@example.com"},
+				App:        App{ID: 640199958, BundleID: "developer.apple.wwdc-Release"},
+				OutputPath: tempDir,
+				Platform:   PlatformMacOS,
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.DestinationPath).To(Equal(requestedPath))
+			Expect(out.Sinfs).To(Equal([]Sinf{{ID: 0, Data: []byte("mobile sinf")}}))
+			Expect(requestedPath).To(BeAnExistingFile())
+			Expect(requestedPath + macEncryptedStageSuffix).ToNot(BeAnExistingFile())
+			Expect(requestedPath + macDecryptedStageSuffix).ToNot(BeAnExistingFile())
 		})
 
 		It("uses a pkg name derived from the generated package name", func() {

--- a/pkg/appstore/appstore_download_test.go
+++ b/pkg/appstore/appstore_download_test.go
@@ -828,6 +828,7 @@ var _ = Describe("AppStore (Download)", func() {
 				os:             operatingsystem.New(),
 				macDecrypterFactory: func(context.Context, []byte, []byte) (macPackageDecrypter, error) {
 					Fail("mobile packages must not initialize the macOS package decrypter")
+
 					return nil, nil
 				},
 			}


### PR DESCRIPTION
## Summary

- detect iOS app packages returned for apps available on macOS
- route those packages through the existing IPA pipeline while preserving native macOS package handling
- reject conflicting or incomplete package metadata
- add Ginkgo coverage for package classification and SINF replication

## Testing

- `go generate ./...`
- `go test ./...`
- `go build ./...`
- `go vet ./...`
- `go test -race ./pkg/appstore ./cmd`
- live download of `developer.apple.wwdc-Release` using `--platform macos`